### PR TITLE
Added closing anchor tag.

### DIFF
--- a/bootstrap/templates/tags.html
+++ b/bootstrap/templates/tags.html
@@ -3,7 +3,7 @@
 {% block content %}
 <ul>
 {% for tag, articles in tags %}
-	<li><a href="{{ SITEURL }}/tag/{{ tag }}.html">{{ tag }}</li>
+	<li><a href="{{ SITEURL }}/tag/{{ tag }}.html">{{ tag }}</a></li>
 {% endfor %}
 </ul>
 {% endblock %}


### PR DESCRIPTION
Closing anchor tag was missing in tags.html of Bootstrap theme.
