### PR TITLE
Fix worng url for "pages" on most templates.

### DIFF
--- a/Just-Read/templates/base.html
+++ b/Just-Read/templates/base.html
@@ -40,7 +40,7 @@
 	<div class="wrapper pages">
 		<ul class="nav">
 		{% for p in PAGES %}
-			<li><a href="{{ SITEURL }}{{ p.url }}">{{ p.title }}</a></li>
+			<li><a href="{{ SITEURL }}/{{ p.url }}">{{ p.title }}</a></li>
 		{% endfor %}
 			<li><a href="{{ SITEURL }}/archives.html">Archive</a></li>
 		</ul>

--- a/bootlex/templates/base.html
+++ b/bootlex/templates/base.html
@@ -31,7 +31,7 @@
               {% if PAGES %}
               <li class="nav-header">Seiten</li>
               {% for p in PAGES %}
-              <li{% if p == page %} class="active"{% endif %}><a href="{{ SITEURL }}{{ p.url }}">{{ p.title }}</a></li>
+              <li{% if p == page %} class="active"{% endif %}><a href="{{ SITEURL }}/{{ p.url }}">{{ p.title }}</a></li>
               {% endfor %}
               {% endif %}
               {% else %}

--- a/bootstrap/templates/base.html
+++ b/bootstrap/templates/base.html
@@ -31,7 +31,7 @@
 				{% endfor %}
 				{% if DISPLAY_PAGES_ON_MENU %}
 					{% for page in PAGES %}
-						<li><a href="{{ SITEURL }}{{ page.url }}">{{ page.title }}</a></li>
+						<li><a href="{{ SITEURL }}/{{ page.url }}">{{ page.title }}</a></li>
 					{% endfor %}
 				{% endif %}
 				{% for cat, null in categories %}

--- a/brownstone/templates/base.html
+++ b/brownstone/templates/base.html
@@ -40,7 +40,7 @@ Released   : 20100928
 							<li><a href="{{ SITEURL }}/archives.html">Archives</a></li>
 							{% if DISPLAY_PAGES_ON_MENU %}
                                                         {% for page in PAGES %}
-                                                            <li><a href="{{ SITEURL }}{{ page.url }}">{{ page.title }}</a></li>
+                                                            <li><a href="{{ SITEURL }}/{{ page.url }}">{{ page.title }}</a></li>
                                                         {% endfor %}
                                                         {% endif %}
 						</ul>

--- a/brownstone/templates/page.html
+++ b/brownstone/templates/page.html
@@ -3,7 +3,7 @@
 {% block content %}        
 <div id="content">
 <div class="post">    
-    <h2 class="title"><a href="{{ SITEURL }}{{ page.url }}">{{ page.title }}</a></h1>
+    <h2 class="title"><a href="{{ SITEURL }}/{{ page.url }}">{{ page.title }}</a></h1>
     {% if PDF_PROCESSOR %}<a href="{{ SITEURL }}/pdf/{{ page.slug }}.pdf">get
     the pdf</a>{% endif %}
     <div style="clear: both;">&nbsp;</div>

--- a/lightweight/templates/menu.html
+++ b/lightweight/templates/menu.html
@@ -2,7 +2,7 @@
   <a href="{{ SITEURL }}/index.html">Accueil</a>
   {% if DISPLAY_PAGES_ON_MENU != False%}
     {% for p in PAGES %}
-  <a {% if p == page %}class="active" {% endif %}href="{{ SITEURL }}{{ p.url }}">{{ p.title }}</a>
+  <a {% if p == page %}class="active" {% endif %}href="{{ SITEURL }}/{{ p.url }}">{{ p.title }}</a>
     {% endfor %}
   {% else %}
   <a href="{{ SITEURL }}/categories.html">Catégories</a>

--- a/lightweight/templates/page.html
+++ b/lightweight/templates/page.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 {% block title %}{{ page.title }}{% endblock %}
 {% block content %}        
-    <h2 class="page_title"><a href="{{ SITEURL }}{{ page.url }}">{{ page.title }}</a></h1>
+    <h2 class="page_title"><a href="{{ SITEURL }}/{{ page.url }}">{{ page.title }}</a></h1>
     {% if PDF_PROCESSOR %}<a href="{{ SITEURL }}/pdf/{{ page.slug }}.pdf">get
     the pdf</a>{% endif %}
     <div style="clear: both;">&nbsp;</div>

--- a/mnmlist/templates/base.html
+++ b/mnmlist/templates/base.html
@@ -30,7 +30,7 @@
             <nav>
                 <ul>
                 {% for page in PAGES %}
-                    <li><a href="{{ SITEURL }}{{ page.url }}">{{ page.title }}</a>{% if not loop.last %} ::{% endif %}</li>
+                    <li><a href="{{ SITEURL }}/{{ page.url }}">{{ page.title }}</a>{% if not loop.last %} ::{% endif %}</li>
                 {% endfor %}
                 {% if categories|length > 1 %}
                     <li>:: <a href="{{ SITEURL }}/categories.html">Catégories</a></li>

--- a/notmyidea-cms-fr/templates/base.html
+++ b/notmyidea-cms-fr/templates/base.html
@@ -34,7 +34,7 @@
                 <li><a href="{{ SITEURL }}/index.html">Accueil</a></li>
                 <li><a href="{{ SITEURL }}/archives.html">Archives</a></li>
                 {% for p in PAGES %}
-                    <li {% if p == page %}class="active"{% endif %}><a href="{{ SITEURL }}{{ p.url }}">{{ p.title }}</a></li>
+                    <li {% if p == page %}class="active"{% endif %}><a href="{{ SITEURL }}/{{ p.url }}">{{ p.title }}</a></li>
                 {% endfor %}
                 {% endif %}
                 {#{% for cat, null in categories %}

--- a/notmyidea-cms-fr/templates/index.html
+++ b/notmyidea-cms-fr/templates/index.html
@@ -59,7 +59,7 @@
 <section id="content" class="body">    
 <h2>Pages</h2>
 {% for page in PAGES %}
-    <li><a href="{{ SITEURL }}{{ page.url }}">{{ page.title }}</a></li>
+    <li><a href="{{ SITEURL }}/{{ page.url }}">{{ page.title }}</a></li>
 {% endfor %}
 </section>
 {% endif %}

--- a/notmyidea-cms/templates/base.html
+++ b/notmyidea-cms/templates/base.html
@@ -33,7 +33,7 @@
                 {% if DISPLAY_PAGES_ON_MENU != False %}
                 <li><a href="{{ SITEURL }}/index.html">Home</a></li>
                 {% for p in PAGES %}
-                    <li {% if p == page %}class="active"{% endif %}><a href="{{ SITEURL }}{{ p.url }}">{{ p.title }}</a></li>
+                    <li {% if p == page %}class="active"{% endif %}><a href="{{ SITEURL }}/{{ p.url }}">{{ p.title }}</a></li>
                 {% endfor %}
                 {% endif %}
                 {#{% for cat, null in categories %}

--- a/notmyidea-cms/templates/index.html
+++ b/notmyidea-cms/templates/index.html
@@ -36,7 +36,7 @@
 <section id="content" class="body">
 <h2>Pages</h2>
 {% for page in PAGES %}
-    <li><a href="{{ SITEURL }}{{ page.url }}">{{ page.title }}</a></li>
+    <li><a href="{{ SITEURL }}/{{ page.url }}">{{ page.title }}</a></li>
 {% endfor %}
 </section>
 {% endif %}

--- a/sneakyidea/templates/base.html
+++ b/sneakyidea/templates/base.html
@@ -33,7 +33,7 @@
                 {% if DISPLAY_PAGES_ON_MENU %}
                     {% for current_page in PAGES %}
                         <li {% if page %}{% if page == current_page%}class="active"{% endif %}{% endif %}>
-                            <a href="{{ SITEURL }}{{ current_page.url }}">{{ current_page.title }}</a>
+                            <a href="{{ SITEURL }}/{{ current_page.url }}">{{ current_page.title }}</a>
                         </li>
                     {% endfor %}
                 {% endif %}

--- a/sneakyidea/templates/index.html
+++ b/sneakyidea/templates/index.html
@@ -39,7 +39,7 @@
 <section id="content" class="body">    
 <h2>Pages</h2>
 {% for page in PAGES %}
-    <li><a href="{{ SITEURL }}{{ page.url }}">{{ page.title }}</a></li>
+    <li><a href="{{ SITEURL }}/{{ page.url }}">{{ page.title }}</a></li>
 {% endfor %}
 </section>
 {% endif %}

--- a/waterspill/templates/base.html
+++ b/waterspill/templates/base.html
@@ -46,7 +46,7 @@
 	<h3>Pages</h3>
 	<ul>
         {% for page in PAGES %}
-            <li><a href="{{ SITEURL }}{{ page.url }}">{{ page.title }}</a></li>
+            <li><a href="{{ SITEURL }}/{{ page.url }}">{{ page.title }}</a></li>
         {% endfor %}
 	</ul>
         {% endif %}

--- a/waterspill/templates/page.html
+++ b/waterspill/templates/page.html
@@ -3,7 +3,7 @@
 {% block content %}        
 
 <div class="blogItem">
-    <h2><a href="{{ SITEURL }}{{ page.url }}">{{ page.title }}</a></h3>
+    <h2><a href="{{ SITEURL }}/{{ page.url }}">{{ page.title }}</a></h3>
 	{{ page.content }}
     {% include 'twitter.html' %}
 


### PR DESCRIPTION
Page objects for PAGES already contain the proper `url` attribute.
Having the templates with /pages/ causes the generated links to be wrong - the resulting url is `/pages/pages/x` whereas it should be `/pages/x`.
