### PR TITLE
Enabling responsive features

### DIFF
--- a/tuxlite_tbs/templates/base.html
+++ b/tuxlite_tbs/templates/base.html
@@ -5,6 +5,7 @@
     <title>{% block windowtitle %}{{ SITENAME }}{% endblock %}</title>
     <meta name="description" content="">
     <meta name="author" content="{{ AUTHOR }}">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
     <!-- Le HTML5 shim, for IE6-8 support of HTML elements -->
     <!--[if lt IE 9]>


### PR DESCRIPTION
Hi. I discovered that **tuxlite_tbs** theme is not changing to "mobile layout" on mobile devices. I t looks like responsive features of Bootstrap was not enabled in the template.

According to http://twitter.github.com/bootstrap/scaffolding.html#responsive the template is missing "viewport" HTML tag.

...tstrap/scaffolding.html#responsive).
