### PR TITLE
Replace FEED with FEED_ATOM

### DIFF
--- a/tuxlite_tbs/templates/base.html
+++ b/tuxlite_tbs/templates/base.html
@@ -69,9 +69,9 @@
             
                 <li><a href="{{ SITEURL }}/archives.html">Archives</a>
                 <li><a href="{{ SITEURL }}/tags.html">Tags</a>
-                <li><a href="{{ SITEURL }}/{{ FEED_ATOM }}" rel="alternate">Atom feed</a></li>
+                <li><a href="{{ FEED_DOMAIN }}/{{ FEED_ATOM }}" rel="alternate">Atom feed</a></li>
                 {% if FEED_RSS %}
-                <li><a href="{{ SITEURL }}/{{ FEED_RSS }}" rel="alternate">RSS feed</a></li>
+                <li><a href="{{ FEED_DOMAIN }}/{{ FEED_RSS }}" rel="alternate">RSS feed</a></li>
                 {% endif %}
             </ul>
             </div>


### PR DESCRIPTION
I fixed missing FEED tags in tuxlite_tbs theme by replacing it with FEED_ATOM. Also, I replaced SITE_URL in the feed links with FEED_DOMAIN for Feedburner support.
