### PR TITLE
Updated installation instructions for Syte

### DIFF
--- a/syte/README.md
+++ b/syte/README.md
@@ -21,7 +21,9 @@ All these settings are optional, not using them will simply not enable the socia
 
 ###### Not so optional
 
-Pelican-syte uses the webassets module integrated into Pelican, so you will also need to install it ( `pip install webassets` ) and add the `WEBASSETS = True` setting.
+Pelican-syte uses the webassets module integrated into Pelican, so you
+will also need to install it ( `pip install webassets` ) and add the
+`pelican.plugins.assets` plugin to `PLUGINS` setting.
 
 #### Links
 


### PR DESCRIPTION
I tried to install the syte theme, but it failed with

`Encountered unknown tag assets`

After a bit of digging, I found that pelican now requires the 'pelican.plugins.assets` plugin to be installed
for the syte theme to work.
