### PR TITLE
Set disqus_title

### DIFF
--- a/tuxlite_tbs/templates/disqus.html
+++ b/tuxlite_tbs/templates/disqus.html
@@ -2,6 +2,7 @@
 <div id="disqus_thread"></div>
 <script type="text/javascript">
     var disqus_shortname = '{{ DISQUS_SITENAME }}'; 
+    var disqus_title = '{{ article.title }}';
 
     (function() {
         var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;


### PR DESCRIPTION
If disqus_title is not set, Disqus will use the title of the site to name a thread. Use article.title as disqus_title instead.
