### PR TITLE
Fixing broken support for `ARCHIVES_URL` in tuxlite-tbs theme.

### DIFF
--- a/tuxlite_tbs/templates/archives.html
+++ b/tuxlite_tbs/templates/archives.html
@@ -9,7 +9,7 @@
     {% for article in dates %}
         <tr>
         <td>{{ article.date.strftime("%d %b %Y") }}</td>
-        <td><a href='{{ article.url }}'>{{ article.title }}</a></td>
+        <td><a href='{{ SITEURL }}/{{ article.url }}'>{{ article.title }}</a></td>
         </tr>
     {% endfor %}
     </tbody>

--- a/tuxlite_tbs/templates/base.html
+++ b/tuxlite_tbs/templates/base.html
@@ -68,7 +68,7 @@
                 Site
                 </li>
             
-                <li><a href="{{ SITEURL }}/archives.html">Archives</a>
+                <li><a href="{{ SITEURL }}/{{ ARCHIVES_URL }}">Archives</a>
                 <li><a href="{{ SITEURL }}/tags.html">Tags</a>
                 <li><a href="{{ FEED_DOMAIN }}/{{ FEED_ATOM }}" rel="alternate">Atom feed</a></li>
                 {% if FEED_RSS %}


### PR DESCRIPTION
This commit fixes an issue with users supplying their own custom `ARCHIVES_URL`
setting in their settings file while using the tuxlite-tbs theme.

The issue is that the `base.html` template didn't take the `ARCHIVES_URL`
variable into account, and therefore ignores is. This causes problems when users
want a custom archives URL.

This also fixes another part of the issue in the `archives.html` template, in
which article URLs were relative (not absolute) which causes breakage when
linking to articles.

This commit fixes all the above problems.
