### PR TITLE
fix mnmlist theme's footer link for pages

### DIFF
--- a/mnmlist/templates/base.html
+++ b/mnmlist/templates/base.html
@@ -30,7 +30,7 @@
             <nav>
                 <ul>
                 {% for page in PAGES %}
-                    <li><a href="{{ SITEURL }}/{{ page.url }}">{{ page.title }}</a>{% if not loop.last %} ::{% endif %}</li>
+                    <li><a href="{{ SITEURL }}/pages/{{ page.url }}">{{ page.title }}</a>{% if not loop.last %} ::{% endif %}</li>
                 {% endfor %}
                 {% if categories|length > 1 %}
                     <li>:: <a href="{{ SITEURL }}/categories.html">Catégories</a></li>


### PR DESCRIPTION
Was the base.html template had a missing "pages/" in the links to the pages.
