### PR TITLE
Clone repository recursively, submodule'ed themes

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -18,7 +18,7 @@ directory ``~/pelican-themes``, but yours could be different. Clone the
 
 .. code-block:: sh
 
-	git clone https://github.com/getpelican/pelican-themes ~/pelican-themes
+	git clone --recursive https://github.com/getpelican/pelican-themes ~/pelican-themes
 
 Now you should have your ``pelican-themes`` repository stored at
 ``~/pelican-themes/``.


### PR DESCRIPTION
Git submodules are great to keep track of themes without having to manage them all in one repository. But cloning the main repository only gets you empty folders for the submodule themes; an additional init is needed.

It's easier and more convenient to just clone the main repository recursively, in order to pull in all themes.
