### PR TITLE
Fixed tag url error in sidebar(gum theme).

### DIFF
--- a/gum/templates/sidebar.html
+++ b/gum/templates/sidebar.html
@@ -33,7 +33,7 @@
 {% if tags %}
 	<ul>
 	{% for tag in tag_cloud %}
-	    <li class="tag-{{ tag.1 }}"><a href="{{ SITEURL }}/tag/{{ tag.0|string|replace(" ", "-" )|lower }}.html">{{ tag.0 }}</a></li>
+    <li class="tag-{{ tag.1 }}"><a href="{{ SITEURL }}/tag/{{ tag.0.url }}">{{ tag.0 }}</a></li>
 	{% endfor %}
 </ul>
 {% endif %}


### PR DESCRIPTION
In gum theme.
if post tag is Chinese. The pelican generated file name for tag is pinyin for Chinese.

```
In pelican:
[ "你好" tag ] convert to [ ni-hao.html ] 
```

So, used `{{ tag.0 }}` in tag link is not idea. Because `{{ tag.0 }}` is "你好" not "ni-hao".
May be the problem also exist in other language. I humbly recommend `{{ tag.0.url }}`. It will generate "ni-hao.html".

thx.
:P
