### PR TITLE
BUG: fix mnmlist theme page title link address

### DIFF
--- a/mnmlist/templates/page.html
+++ b/mnmlist/templates/page.html
@@ -3,7 +3,7 @@
 {% block content %}        
 <header>
     <h1><a href="{{ SITEURL }}" id="site-title">{{ SITENAME }} {% if SITESUBTITLE %} <strong>{{ SITESUBTITLE }}</strong>{% endif %}</a> :
-        <a href="{{ SITEURL }}/{{ page.slug }}" id="page-title">{{ page.title }}</a></h1>
+        <a href="{{ SITEURL }}/{{ page.url }}" id="page-title">{{ page.title }}</a></h1>
 </header>
 <article>    
     {{ page.content }}


### PR DESCRIPTION
In the mnmlist theme if you manually specify a url in a page's metadata then the header link is incorrect.

This PR fixes that by linking to `page.url` and not `page.slug`
