### PR TITLE
Gum: Fix tag URLs not being slugified

### DIFF
--- a/gum/templates/sidebar.html
+++ b/gum/templates/sidebar.html
@@ -33,7 +33,7 @@
 {% if tags %}
 	<ul>
 	{% for tag in tag_cloud %}
-	    <li class="tag-{{ tag.1 }}"><a href="{{ SITEURL }}/tag/{{ tag.0|string|replace(" ", "-" )|lower }}.html">{{ tag.0 }}</a></li>
+	    <li class="tag-{{ tag.1 }}"><a href="{{ SITEURL }}/{{ tag.0.url }}">{{ tag.0 }}</a></li>
 	{% endfor %}
 </ul>
 {% endif %}


### PR DESCRIPTION
This causes URLs to be broken when the original tag name is not identical to the slugified version.
