### PR TITLE
Fix path issue for archive pages

### DIFF
--- a/mnmlist/templates/archives.html
+++ b/mnmlist/templates/archives.html
@@ -6,7 +6,7 @@
 <dl>
 {% for article in dates %}
     <dt>{{ article.locale_date }}</dt>
-    <dd><a href='{{ article.url }}'>{{ article.title }}</a></dd>
+    <dd><a href='{{ SITEURL }}/{{ article.url }}'>{{ article.title }}</a></dd>
 {% endfor %}
 </dl>
 </section>


### PR DESCRIPTION
This fixes paths for archive pages. 
- Previously hyperlinks pointed to current page appended with article url
- now links will point to site url appended with article url

Tested with Year and Month Archive pages successfully.
