### PR TITLE
URL and name were being displayed incorrectly.

### DIFF
--- a/gum/templates/sidebar.html
+++ b/gum/templates/sidebar.html
@@ -43,7 +43,7 @@
 <nav class="widget">
   <h4>Social</h4>
   <ul>
-  {% for url, name in SOCIAL %}
+  {% for name, url in SOCIAL %}
     <li><a href="{{ url|e }}">{{ name }}</a></li>
   {% endfor %}
   </ul>


### PR DESCRIPTION
Format in pelicanconf.py is as follow.
# Social widget

SOCIAL = (
    ('GitHub', 'https://github.com/<user>'),
)
