### PR TITLE
Removed bootstrap-glyphicons.css as it throws 404 exception in server an...

### DIFF
--- a/pelican-bootstrap3/templates/base.html
+++ b/pelican-bootstrap3/templates/base.html
@@ -46,7 +46,6 @@
         <link rel="stylesheet" href="{{ SITEURL }}/theme/css/bootstrap.min.css" type="text/css"/>
     {% endif %}
     <link href="{{ SITEURL }}/theme/css/font-awesome.min.css" rel="stylesheet">
-    <link href="{{ SITEURL }}/theme/css/bootstrap-glyphicons.css" rel="stylesheet">
     <link href="{{ SITEURL }}/theme/css/pygments.css" rel="stylesheet">
     <link rel="stylesheet" href="{{ SITEURL }}/theme/css/style.css" type="text/css"/>
     <!-- JavaScript plugins (requires jQuery) -->


### PR DESCRIPTION
Removed bootstrap-glyphicons.css as it throws 404 exception in server and is not necessary in the release version of bootstrap 3.
