### PR TITLE
Fix the bug that cannot load the disqus

### DIFF
--- a/pelican-bootstrap3/templates/includes/comments.html
+++ b/pelican-bootstrap3/templates/includes/comments.html
@@ -4,13 +4,13 @@
         <h2>Comments</h2>
         <div id="disqus_thread"></div>
         <script type="text/javascript">
-			var disqus_shortname = '{{ DISQUS_SITENAME }}'; 
-			var disqus_title = '{{ article.title }}';
-			(function() {
-				var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;
-				dsq.src = 'http://' + disqus_shortname + '.disqus.com/embed.js';
-				(document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);
-			})();
+            var disqus_shortname = '{{ DISQUS_SITENAME }}'; 
+            var disqus_title = '{{ article.title }}';
+            (function() {
+                var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;
+                dsq.src = 'http://' + disqus_shortname + '.disqus.com/embed.js';
+                (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);
+            })();
         </script>
         <noscript>Please enable JavaScript to view the <a href="http://disqus.com/?ref_noscript">comments powered by
             Disqus.</a></noscript>


### PR DESCRIPTION
When I used original comments.html to load my disqus, I found it can not work. So I used code in tuxlite_tbs/disqus.html to replace the original code and my disqus worked! : )
