### PR TITLE
Adding a "screenshot" section to those readme files that don't have one

### DIFF
--- a/Just-Read/readme.md
+++ b/Just-Read/readme.md
@@ -9,3 +9,7 @@
 - the **psd folder** contains the images used in the theme, handful if you want to change the color scheme.
 
 *Note: I tested the theme only in the latests version of Chrome, Firefox, Opera and Safari. *
+
+## Screenshot ##
+
+![screenshot](screenshot.png)

--- a/basic/README.rst
+++ b/basic/README.rst
@@ -11,5 +11,5 @@ Screenshot
 ----------
 
 .. image:: screenshot.png
-   :alt: Sreenshot of the basic theme
+   :alt: Screenshot of the basic theme
 

--- a/bootlex/README.md
+++ b/bootlex/README.md
@@ -43,3 +43,7 @@ You can make use of the following settings:
 # Missing
 
 I do not know whether it works, but as I never cared about it, I suppose that categorys will not work properly
+
+## Screenshot ##
+
+![screenshot](screenshot.png)

--- a/bootstrap/README.md
+++ b/bootstrap/README.md
@@ -1,0 +1,7 @@
+# bootstrap #
+
+
+
+## Screenshot ##
+
+![screenshot](screenshot.png)

--- a/bootstrap2/README.rst
+++ b/bootstrap2/README.rst
@@ -9,3 +9,9 @@ and try to keep other features from Pelican's default theme ``notmyidea``.
 Also you can see its result from `my Github Page <http://farseerfc.github.com/>`_. It will be updated using latest theme.
 
 Feel free to use it.
+
+Screenshot
+----------
+
+.. image:: screenshot.png
+   :alt: Screenshot of the theme

--- a/brownstone/README.md
+++ b/brownstone/README.md
@@ -1,0 +1,7 @@
+# brownstone #
+
+
+
+## Screenshot ##
+
+![screenshot](screenshot.png)

--- a/cebong/README.markdown
+++ b/cebong/README.markdown
@@ -1,5 +1,4 @@
-pelican-cebong-theme
-===============
+# pelican-cebong-theme #
 
 This theme is focused on simplicity and solarized-looks, its structure was derived from the pelican's *notmyidea* theme, and I altered some stuff to look more like [my old tumblr blog](http://kecebongsoft.tumblr.com), which is pretty much solarized-like.
 
@@ -8,3 +7,8 @@ This theme is used for [my pelican blog](http://kecebongsoft.com).
 You can add a tagline below the title using `SITETAGLINE`, and add
 additional footer information with `FOOTERTEXT`
 
+## Screenshots ##
+
+![screenshot1](screenshot-article.png)
+![screenshot2](screenshot-with-tagline.png)
+![screenshot3](screenshot-without-tagline.png)

--- a/dev-random/README.md
+++ b/dev-random/README.md
@@ -1,0 +1,7 @@
+# dev-random #
+
+
+
+## Screenshot ##
+
+![screenshot](screenshot.png)

--- a/dev-random2/README.md
+++ b/dev-random2/README.md
@@ -1,0 +1,7 @@
+# dev-random2 #
+
+
+
+## Screenshot ##
+
+![screenshot](screenshot.png)

--- a/gum/README.md
+++ b/gum/README.md
@@ -24,6 +24,11 @@ GOOGLE_ANALYTICS_ID = ''
 GOOGLE_ANALYTICS_SITENAME = ''
 ```
 
+
+### Screenshot ###
+
+![screenshot](screenshot.png)
+
 ### Credits / Thanks
 
  * Alexis Metaireau / Pelican

--- a/lightweight/README.md
+++ b/lightweight/README.md
@@ -1,0 +1,7 @@
+# lightweight #
+
+
+
+## Screenshot ##
+
+![screenshot](screenshot.png)

--- a/martyalchin/README.md
+++ b/martyalchin/README.md
@@ -1,0 +1,7 @@
+# martyalchin #
+
+
+
+## Screenshot ##
+
+![screenshot](screenshot.png)

--- a/mnmlist/README.rst
+++ b/mnmlist/README.rst
@@ -20,3 +20,9 @@ Compass
 ~~~~~~~
 
 The ``main.css`` file is generated from the ``compass/src/main.scss`` sass file, using http://compass-style.org/.
+
+Screenshot
+----------
+
+.. image:: screenshot.png
+   :alt: Screenshot of the theme

--- a/monospace/README.md
+++ b/monospace/README.md
@@ -2,7 +2,9 @@
 monospace
 ==========
 Theme adapted from [monospace for wordpress](http://wordpress.org/themes/monospace)
-Here is a [screengrab](https://github.com/lwm/pelican-themes/blob/master/monospace/screenshot.png) for your viewing pleasure.
+Here is a screenshot for your viewing pleasure:
+
+![screengrab](screenshot.png)
 
 If you are using ``Markdown`` you need to include the following option in your ``pelicanconf.py`` for syntax highlighting.
 

--- a/nmnlist/README.rst
+++ b/nmnlist/README.rst
@@ -20,3 +20,9 @@ Compass
 ~~~~~~~
 
 The ``main.css`` file is generated from the ``compass/src/main.scss`` sass file, using http://compass-style.org/.
+
+Screenshot
+----------
+
+.. image:: screenshot.png
+   :alt: Screenshot of the theme

--- a/notmyidea-cms-fr/README.md
+++ b/notmyidea-cms-fr/README.md
@@ -1,0 +1,7 @@
+# notmyidea-cms-fr #
+
+
+
+## Screenshot ##
+
+![screenshot](screenshot.png)

--- a/notmyidea-cms/README.md
+++ b/notmyidea-cms/README.md
@@ -1,0 +1,7 @@
+# notmyidea-cms #
+
+
+
+## Screenshot ##
+
+![screenshot](screenshot.png)

--- a/simple-bootstrap/readme.md
+++ b/simple-bootstrap/readme.md
@@ -1,1 +1,5 @@
 this is a simple bootstrap pelican theme based on bootstrap [Narrow jumbotron](http://getbootstrap.com/examples/jumbotron-narrow/) template
+
+## Screenshot ##
+
+![screenshot](screenshot.png)

--- a/sneakyidea/README.rst
+++ b/sneakyidea/README.rst
@@ -8,3 +8,9 @@ To make the tag cloud accessible from the navigation bar add ::
     $ MENUITEMS = (('Tags', 'tags.html'),)
 
 in your settings.
+
+Screenshot
+----------
+
+.. image:: screenshot.png
+   :alt: Screenshot of the theme

--- a/tuxlite_tbs/README.md
+++ b/tuxlite_tbs/README.md
@@ -1,0 +1,7 @@
+# tuxlite_tbs #
+
+
+
+## Screenshot ##
+
+![screenshot](screenshot.png)

--- a/tuxlite_zf/README.md
+++ b/tuxlite_zf/README.md
@@ -10,4 +10,4 @@ Menu items and pages can be added to the top navigation bar via pelican settings
 
 Screenshot below.
 
-![Screenshot](https://raw.github.com/mins/pelican-themes/master/tuxlite_zf/Screenshot.png)
+![Screenshot](Screenshot.png)

--- a/waterspill-en/README.md
+++ b/waterspill-en/README.md
@@ -1,0 +1,7 @@
+# waterspill-en #
+
+
+
+## Screenshot ##
+
+![screenshot](screenshot.png)

--- a/waterspill/README.md
+++ b/waterspill/README.md
@@ -1,0 +1,7 @@
+# waterspill #
+
+
+
+## Screenshot ##
+
+![screenshot](screenshot.png)


### PR DESCRIPTION
This makes it easier to browse the themes from GitHub. :)
