### PR TITLE
github activity: allow sorting by an arbitrary attribute (GITHUB_SORT_AT...

### DIFF
--- a/pelican-bootstrap3/static/js/github.js
+++ b/pelican-bootstrap3/static/js/github.js
@@ -24,13 +24,11 @@ var github = (function(){
             repos.push(data.data[i]);
           }
           repos.sort(function(a, b) {
-            var aDate = new Date(a.pushed_at).valueOf(),
-                bDate = new Date(b.pushed_at).valueOf();
-
-            if (aDate === bDate) { return 0; }
-            return aDate > bDate ? -1 : 1;
+            if (a[options.sort_attribute] > b[options.sort_attribute]) { return 1; }
+            if (a[options.sort_attribute] < b[options.sort_attribute]) { return -1; }
+            return 0;
           });
-
+          if (options.sort_descending) { repos.reverse(); }
           if (options.count) { repos.splice(options.count); }
           render(options.target, repos);
         }

--- a/pelican-bootstrap3/templates/includes/github.html
+++ b/pelican-bootstrap3/templates/includes/github.html
@@ -12,6 +12,18 @@
             {% set GITHUB_SKIP_FORK = "false" %}
         {% endif %}
     {% endif %}
+    {% if GITHUB_SORT_ATTRIBUTE is not defined %}
+        {% set GITHUB_SORT_ATTRIBUTE = "pushed_at" %}
+    {% endif %}
+    {% if GITHUB_SORT_DESCENDING is not defined %}
+        {% set GITHUB_SORT_DESCENDING = "true" %}
+    {% else %}
+        {% if GITHUB_SORT_DESCENDING %}
+            {% set GITHUB_SORT_DESCENDING = "true" %}
+        {% else %}
+            {% set GITHUB_SORT_DESCENDING = "false" %}
+        {% endif %}
+    {% endif %}
 
     <section>
     <ul class="list-group list-group-flush">
@@ -37,7 +49,9 @@
                     user: '{{ GITHUB_USER }}',
                     count: {{ GITHUB_REPO_COUNT }},
                     skip_forks: {{ GITHUB_SKIP_FORK }},
-                    target: '#gh_repos'
+                    target: '#gh_repos',
+                    sort_attribute: '{{ GITHUB_SORT_ATTRIBUTE }}',
+                    sort_descending: {{ GITHUB_SORT_DESCENDING }}
                 });
             });
         </script>


### PR DESCRIPTION
This patch extends the GitHub activity sidebar widget such that one can sort by an arbitrary repo property (default `pushed_at`), say `stargazers_count` and in both ascending and descending order.

Let me know if I should amend `README.MD` accordingly.
