### PR TITLE
GitHub activity: allow sorting by an arbitrary attribute

### DIFF
--- a/pelican-bootstrap3/README.md
+++ b/pelican-bootstrap3/README.md
@@ -37,9 +37,11 @@ Categories are disabled by default because I don't use them myself. If you want 
 
 The theme can show your most recently active GitHub repos in the sidebar. To enable, provide a `GITHUB_USER`. Appearance and behaviour can be controlled using the following variables:
 
-* `GITHUB_REPO_COUNT`
-* `GITHUB_SKIP_FORK`
-* `GITHUB_SHOW_USER_LINK`
+* `GITHUB_REPO_COUNT` (default: `5`)
+* `GITHUB_SKIP_FORK` (default: `False`)
+* `GITHUB_SHOW_USER_LINK` (default: `True`)
+* `GITHUB_SORT_ATTRIBUTE` (default: `pushed_at`, for other attributes like `stargazers_count` cf. `https://api.github.com/users/<GITHUB_USER>/repos`)
+* `GITHUB_SORT_DESCENDING` (default: `True`)
 
 ### Bootswatch and other Bootstrap 3 themes
 

--- a/pelican-bootstrap3/static/js/github.js
+++ b/pelican-bootstrap3/static/js/github.js
@@ -24,13 +24,11 @@ var github = (function(){
             repos.push(data.data[i]);
           }
           repos.sort(function(a, b) {
-            var aDate = new Date(a.pushed_at).valueOf(),
-                bDate = new Date(b.pushed_at).valueOf();
-
-            if (aDate === bDate) { return 0; }
-            return aDate > bDate ? -1 : 1;
+            if (a[options.sort_attribute] > b[options.sort_attribute]) { return 1; }
+            if (a[options.sort_attribute] < b[options.sort_attribute]) { return -1; }
+            return 0;
           });
-
+          if (options.sort_descending) { repos.reverse(); }
           if (options.count) { repos.splice(options.count); }
           render(options.target, repos);
         }

--- a/pelican-bootstrap3/templates/includes/github.html
+++ b/pelican-bootstrap3/templates/includes/github.html
@@ -12,6 +12,18 @@
             {% set GITHUB_SKIP_FORK = "false" %}
         {% endif %}
     {% endif %}
+    {% if GITHUB_SORT_ATTRIBUTE is not defined %}
+        {% set GITHUB_SORT_ATTRIBUTE = "pushed_at" %}
+    {% endif %}
+    {% if GITHUB_SORT_DESCENDING is not defined %}
+        {% set GITHUB_SORT_DESCENDING = "true" %}
+    {% else %}
+        {% if GITHUB_SORT_DESCENDING %}
+            {% set GITHUB_SORT_DESCENDING = "true" %}
+        {% else %}
+            {% set GITHUB_SORT_DESCENDING = "false" %}
+        {% endif %}
+    {% endif %}
 
     <section>
     <ul class="list-group list-group-flush">
@@ -37,7 +49,9 @@
                     user: '{{ GITHUB_USER }}',
                     count: {{ GITHUB_REPO_COUNT }},
                     skip_forks: {{ GITHUB_SKIP_FORK }},
-                    target: '#gh_repos'
+                    target: '#gh_repos',
+                    sort_attribute: '{{ GITHUB_SORT_ATTRIBUTE }}',
+                    sort_descending: {{ GITHUB_SORT_DESCENDING }}
                 });
             });
         </script>


### PR DESCRIPTION
This patch extends the GitHub activity sidebar widget such that one can sort by an arbitrary repo property (default `pushed_at`), say `stargazers_count` and in both ascending and descending order.

This one replaces the pull request https://github.com/getpelican/pelican-themes/pull/173. Being quite proficient at other VCS, I still haven't understood how to amend an existing pull request s.t. it arrives as a single commit.
