### PR TITLE
made article tag separator configurable via TAG_LIST_SEPARATOR

### DIFF
--- a/pelican-bootstrap3/README.md
+++ b/pelican-bootstrap3/README.md
@@ -53,6 +53,10 @@ You can enable sharing buttons through [AddThis](http://www.addthis.com/) by set
 
 In order to make the Facebook like button work better, the template contains Open Graph metatags like `<meta property="og:type" content="article"/>`. You can disable them by setting `USE_OPEN_GRAPH` to `False`. You can use `OPEN_GRAPH_FB_APP_ID` to provide a Facebook _app id_. You can also provide a default image that will be passed to Facebook for the homepage of you site by setting `OPEN_GRAPH_IMAGE` to a relative file path, which will be prefixed by your site's static directory.
 
+### Tag List
+
+You can customize the separator between article tags with `TAG_LIST_SEPARATOR`. The default separator is `/`.
+
 ## Screenshot
 
 ![](screenshot.png)

--- a/pelican-bootstrap3/templates/includes/taglist.html
+++ b/pelican-bootstrap3/templates/includes/taglist.html
@@ -1,9 +1,13 @@
 {% if article.tags %}
-<span class="label label-default">Tags</span>
-{% for tag in article.tags %}
-	<a href="{{ SITEURL }}/{{ tag.url }}">{{ tag }}</a>
-    {% if not loop.last %}
-        /
+    {% if TAG_LIST_SEPARATOR is not defined %}
+        {% set TAG_LIST_SEPARATOR = "/" %}
     {% endif %}
-{% endfor %}
+
+	<span class="label label-default">Tags</span>
+	{% for tag in article.tags %}
+		<a href="{{ SITEURL }}/{{ tag.url }}">{{ tag }}</a>
+	    {% if not loop.last %}
+	        {{ TAG_LIST_SEPARATOR }}
+	    {% endif %}
+	{% endfor %}
 {% endif %}


### PR DESCRIPTION
Introduced a new variable `TAG_LIST_SEPARATOR` (default: `/`) which allows to replace the separator between article tags with other typographic symbol like `MIDDLE DOT`.
