### PR TITLE
Fix "git submodule update" failing because the pujangga submodule was pointing at a non-public repo.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -87,7 +87,7 @@
 	url = https://github.com/fle/pelican-simplegrey
 [submodule "pujangga"]
 	path = pujangga
-	url = git@github.com:habibillah/pujangga.git
+	url = https://github.com/habibillah/pujangga.git
 [submodule "lovers"]
 	path = lovers
 	url = https://github.com/chdoig/pelican-bootstrap3-lovers.git


### PR DESCRIPTION
git@github.com:USER/REPO is not a good idea, switch to https://github.com/USER/REPO
