### PR TITLE
Fixed monthly archives to respect MONTH_ARCHIVE_SAVE_AS setting

### DIFF
--- a/foundation-default-colours/templates/base.html
+++ b/foundation-default-colours/templates/base.html
@@ -88,7 +88,7 @@
 						<li><label>Monthly Archives</label></li>
 							{% for year, date_year in dates|groupby( 'date.year' )|sort(reverse=True) %}
 								{% for month, articles in date_year|groupby( 'date.month' )|sort(reverse=True) %}
-									<li><a href="/posts/{{ year }}/{{ articles[0].date.strftime('%m') }}/">{{ articles[0].date.strftime('%B') }} {{ year }} ({{ articles|count }})</a></li>
+									<li><a href="/{{ MONTH_ARCHIVE_SAVE_AS.format(date=articles[0].date) }}">{{ articles[0].date.strftime('%B') }} {{ year }} ({{ articles|count }})</a></li>
 								{% endfor %}
 							{% endfor %}
 						{% endif %}
@@ -158,7 +158,7 @@
 								<ul class="side-nav">
 									{% for year, date_year in dates|groupby( 'date.year' )|sort(reverse=True) %}
 										{% for month, articles in date_year|groupby( 'date.month' )|sort(reverse=True) %}
-											<li><a href="/posts/{{ year }}/{{ articles[0].date.strftime('%m') }}/">{{ articles[0].date.strftime('%B') }} {{ year }} ({{ articles|count }})</a></li>
+											<li><a href="/{{ MONTH_ARCHIVE_SAVE_AS.format(date=articles[0].date) }}">{{ articles[0].date.strftime('%B') }} {{ year }} ({{ articles|count }})</a></li>
 										{% endfor %}
 									{% endfor %}
 								</ul>


### PR DESCRIPTION
The foundation-default-colours theme ignores the format in MONTH_ARCHIVE_SAVE_AS, using the example format from the docs instead.
This change uses the MONTH_ARCHIVE_SAVE_AS format string directly.

(This is a repost of [209](https://github.com/getpelican/pelican-themes/pull/209). I'm new to git and created that one from my master branch.)
