### PR TITLE
Change tag-cloud in foundation-default-colours to respect config

### DIFF
--- a/foundation-default-colours/templates/base.html
+++ b/foundation-default-colours/templates/base.html
@@ -147,7 +147,7 @@
 								<h5>Tags</h5>
 								<ul class="tag-cloud">
 									{% for tag in tag_cloud %}
-									<li><a href="/tag/{{ tag.0|lower|replace(' ', '-') }}/" class="tag-{{ tag.1 }}">{{ tag.0 }}</a></li>
+										<li class="tag-{{ tag.1 }}"><a href="{{ SITEURL }}/{{ tag.0.url }}">{{ tag.0 }}</a></li>
 									{% endfor %}
 								</ul>
 							</div>


### PR DESCRIPTION
The tag-cloud in the foundation-default-colours theme ignores the configuration and instead uses a hardcoded path.

This change replaces that with the example from the docs: http://docs.getpelican.com/en/3.3.0/settings.html#tag-cloud
