### PR TITLE
tuxlite_zf: include analytics.html in base.html for Google Analytics support

### DIFF
--- a/tuxlite_zf/templates/base.html
+++ b/tuxlite_zf/templates/base.html
@@ -110,4 +110,5 @@
             </div>
             </div>
     </div>
+{% include "analytics.html" %}
 </footer>


### PR DESCRIPTION
I've just added a missing include for Google Analaytics support for this theme
