### PR TITLE
Bugfix pelican-bootstrap3 sidebar: missing </ul>

### DIFF
--- a/pelican-bootstrap3/templates/includes/sidebar.html
+++ b/pelican-bootstrap3/templates/includes/sidebar.html
@@ -43,6 +43,7 @@
                                 <i class="fa fa-folder-open fa-lg"></i> {{ cat }}
                             </a>
                         </li>
+                    </ul>
                     {% endfor %}
                 </li>
             {% endif %}


### PR DESCRIPTION
Bugfix for pelican-bootstrap3's sidebar template: there was a missing "&lt;/ul&gt;" tag.
