### PR TITLE
Changed URL to modernizer.js

### DIFF
--- a/zurb-F5-basic/templates/base.html
+++ b/zurb-F5-basic/templates/base.html
@@ -10,7 +10,7 @@
     <link rel="stylesheet" href="{{ SITEURL }}/theme/css/foundation.min.css" />
     <link rel="stylesheet" href="{{ SITEURL }}/theme/css/style.css" />
     <link rel="stylesheet" href="{{ SITEURL }}/theme/css/pygments.css" />	
-    <script src="{{ SITEURL }}/theme/js/custom.modernizr.js"></script>
+    <script src="{{ SITEURL }}/theme/js/modernizr.js"></script>
 </head>
 
 <body>


### PR DESCRIPTION
I get:
WARNING:root:Unable to find file /theme/js/custom.modernizr.js/index.html or variations.
if I generate the site as-is.
Either it links to the one in /vendor or the existing one in /js (called modernizer.js)
