### PR TITLE
pelican-bootstrap3: Add support for coderwall badges

### DIFF
--- a/pelican-bootstrap3/EXAMPLES.md
+++ b/pelican-bootstrap3/EXAMPLES.md
@@ -46,3 +46,5 @@ If your website is listed here, but you don't want it to be, let me know and I'l
 [Jason Antman's Blog](http://blog.jasonantman.com/)  by [jantman](https://github.com/jantman)
 
 [Bryce Boe](http://bryceboe.com/) by [bboe](https://github.com/bboe)
+
+[higeblog](http://www.higebu.com/) by [higebu](https://github.com/higebu)

--- a/pelican-bootstrap3/README.md
+++ b/pelican-bootstrap3/README.md
@@ -210,6 +210,10 @@ The theme can show your most recently active GitHub repos in the sidebar. To ena
 * `GITHUB_SKIP_FORK`
 * `GITHUB_SHOW_USER_LINK`
 
+### Coderwall Badges
+
+The theme can show your [Coderwall](https://coderwall.com/) badges in the sidebar. To enable, provide a `CODERWALL_USER`.
+
 ### Facebook Open Graph
 
 In order to make the Facebook like button and other social sharing options work better, the template contains Open Graph metatags like `<meta property="og:type" content="article"/>`. You can disable them by setting `USE_OPEN_GRAPH` to _False_. You can use `OPEN_GRAPH_FB_APP_ID` to provide a Facebook _app id_. 

--- a/pelican-bootstrap3/templates/base.html
+++ b/pelican-bootstrap3/templates/base.html
@@ -185,6 +185,7 @@
 <script src="{{ SITEURL }}/theme/js/respond.min.js"></script>
 
 {% include 'includes/github-js.html' %}
+{% include 'includes/coderwall-js.html' %}
 {% include 'includes/disqus_script.html' %}
 {% include 'includes/ga.html' %}
 {% include 'includes/piwik.html' %}

--- a/pelican-bootstrap3/templates/includes/coderwall-js.html
+++ b/pelican-bootstrap3/templates/includes/coderwall-js.html
@@ -1,0 +1,15 @@
+{% if CODERWALL_USER %}
+	<script type="text/javascript">
+	$(document).ready(function(){
+		$.getJSON("http://coderwall.com/{{ CODERWALL_USER }}.json?callback=?", function(data){
+			for(var i = 0; i < data.data.badges.length ; i++){
+				var badge = data.data.badges[i];
+				var badge_tag = $("<img />");
+				badge_tag.attr("src",badge.badge);
+				badge_tag.css("width","50%");
+				$("#coderwall_badges").append(badge_tag);
+			}
+		});
+	});
+	</script>
+{% endif %}

--- a/pelican-bootstrap3/templates/includes/coderwall.html
+++ b/pelican-bootstrap3/templates/includes/coderwall.html
@@ -1,0 +1,7 @@
+{% if CODERWALL_USER %}
+	<li class="list-group-item">
+		<h4><i class="fa fa-github-alt fa-lg"></i><span class="icon-label">Coderwall Badges</span></h4>
+		<div id="coderwall_badges"></div>
+		<a href="http://coderwall.com/{{ CODERWALL_USER }}">@{{ CODERWALL_USER }}</a> on coderwall
+	</li>
+{% endif %}


### PR DESCRIPTION
I added [coderwall](https://coderwall.com) badges in the sidebar.
An example is here: http://www.higebu.com/