### PR TITLE
Add missing `</a>` closing tag for Brownstone

### DIFF
--- a/brownstone/templates/base.html
+++ b/brownstone/templates/base.html
@@ -31,7 +31,7 @@ Released   : 20100928
                                 {% endblock %}
 				<div id="sidebar">
 					<div id="logo">
-						<h1><a href="{{ SITEURL }}">{{ SITENAME }}</h1>
+						<h1><a href="{{ SITEURL }}">{{ SITENAME }}</a></h1>
 						{% if SITESUBTITLE %}<p>{{ SITESUBTITLE }}</p>{% endif %}
 					</div>
 					<div id="menu">


### PR DESCRIPTION
Well, at least we noticed...