### PR TITLE
Brownstone: fix wrong categories links in archives.html

### DIFF
--- a/brownstone/templates/archives.html
+++ b/brownstone/templates/archives.html
@@ -8,7 +8,7 @@
 						{% for article in dates %}
                                                     <dt>{{ article.locale_date }}</dt>
                                                     <dd><a href='{{ article.url }}'>{{ article.title }}</a></dd>
-                                                    <dd>Catégorie : <a href="{{ article.category }}">{{ article.category }}</a></dd>
+                                                    <dd>Catégorie : <a href="{{ SITEURL }}/{{ article.category.url }}">{{ article.category }}</a></dd>
                                                 {% endfor %}
                                                 </dl>
 					</div>


### PR DESCRIPTION
The original categories links in the posts in archives.html are wrong, which link to non-existing URLs.