### PR TITLE
Fix linking of screen shots included in the readme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -187,3 +187,6 @@
 [submodule "free-agent"]
 	path = free-agent
 	url = https://github.com/callmefish/pelican-free-agent
+[submodule "mediumfox"]
+	path = mediumfox
+	url = https://github.com/cprieto/pelican-mediumfox


### PR DESCRIPTION
I’ve changed the path to the screenshots so that they should show up when someone browses to the page in github.