### PR TITLE
Add metadata to Cebong theme

### DIFF
--- a/cebong/templates/archives.html
+++ b/cebong/templates/archives.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% block robots %}noindex,follow{% endblock %}
 {% block content %}
 <section id="content" class="body">
 <h1>Archives for {{ SITENAME }}</h1>

--- a/cebong/templates/article.html
+++ b/cebong/templates/article.html
@@ -1,5 +1,33 @@
 {% extends "base.html" %}
+{% block robots %}
+{% if article.robots %}{{ article.robots }}{% else %}index,follow{% endif %}
+{% endblock %}
+{% block head_description %}
+{% if article.summary %}
+{{ article.summary|striptags }}
+{% endif %}
+{% endblock head_description %}
 {% block title %}{{ article.title|striptags }}{% endblock %}
+{% block meta_tags_in_head %}
+{% if article.tags and article.category %}
+        <meta name="keywords" content="{{ [article.tags|join(', '), article.category]|join(', ') }}" />
+{% endif %}
+{% if article.category %}
+        <meta name="category" content="{{ article.category|striptags }}" />
+{% endif %}
+{% if article.description %}
+        <meta name="description" content="{{ article.description|striptags  }}" />
+{% elif article.summary %}
+        <meta name="description" content="{{ article.summary|striptags  }}" />
+{% endif %}
+{% if article.author %}
+        <meta name="author" content="{{ article.author }}" />
+        <meta name="copyright" content="{{ article.author }}" />
+{% endif %}
+{% if article.date %}
+        <meta name="date" content="{{ article.date }}">
+{% endif %}
+{% endblock meta_tags_in_head %}
 {% block content %}
 <section id="content" class="body">
   <article>

--- a/cebong/templates/author.html
+++ b/cebong/templates/author.html
@@ -1,2 +1,3 @@
 {% extends "index.html" %}
+{% block robots %}noindex,follow{% endblock %}
 {% block title %}{{ SITENAME }} - {{ author }}{% endblock %}

--- a/cebong/templates/base.html
+++ b/cebong/templates/base.html
@@ -3,6 +3,18 @@
 <head>
         <title>{% block title %}{{ SITENAME }}{%endblock%}</title>
         <meta charset="utf-8" />
+        <meta name="generator" content="Pelican" />
+        {% if not page and not article %}
+        <meta name="author" content="{{ AUTHOR }}" />
+        <meta name="copyright" content="{{ AUTHOR }}" />
+        {% if SITE_DESCRIPTION %}
+        <meta name="description" content="{% block head_description %}{{ SITE_DESCRIPTION }}{% endblock head_description %}" />
+        {% endif %}
+        {% endif %}
+        {% block meta_tags_in_head %}
+        {% endblock meta_tags_in_head %}
+        <meta name="robots" content="{% block robots %}index,follow{% endblock %}">
+
         <link rel="stylesheet" href="{{ SITEURL }}/theme/css/{{ CSS_FILE }}" type="text/css" />
         {% if FEED_ATOM %}
         <link href="{{ FEED_DOMAIN }}/{{ FEED_ATOM }}" type="application/atom+xml" rel="alternate" title="{{ SITENAME }} Atom Feed" />

--- a/cebong/templates/category.html
+++ b/cebong/templates/category.html
@@ -1,2 +1,3 @@
 {% extends "index.html" %}
+{% block robots %}noindex,follow{% endblock %}
 {% block title %}{{ SITENAME }} - {{ category }}{% endblock %}

--- a/cebong/templates/index.html
+++ b/cebong/templates/index.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% block robots %}noindex,follow{% endblock %}
 {% block content_title %}{% endblock %}
 {% block content %}        
 {% if articles %}

--- a/cebong/templates/page.html
+++ b/cebong/templates/page.html
@@ -1,7 +1,28 @@
 {% extends "base.html" %}
 {% block title %}{{ page.title }}{% endblock %}
-{% block content %}        
-<section id="content" class="body">    
+{% block robots %}
+{% if page.robots %}{{ page.robots }}{% else %}index,follow{% endif %}
+{% endblock %}
+{% block meta_tags_in_head %}
+{% if page.tags and page.category %}
+        <meta name="keywords" content="{{ [page.tags|join(', '), page.category]|join(', ') }}" />
+{% endif %}
+{% if page.category %}
+        <meta name="category" content="{{ page.category|striptags }}" />
+{% endif %}
+{% if page.description %}
+        <meta name="description" content="{{ page.description|striptags  }}" />
+{% elif page.summary %}
+        <meta name="description" content="{{ page.summary|striptags  }}" />
+{% endif %}
+{% if page.author %}
+        <meta name="author" content="{{ page.author }}" />
+        <meta name="copyright" content="{{ page.author }}" />
+{% endif %}
+{% endblock meta_tags_in_head %}
+
+{% block content %}
+<section id="content" class="body">
     <h1 class="entry-title">{{ page.title }}</h1>
     {% if PDF_PROCESSOR %}<a href="{{ SITEURL }}/pdf/{{ page.slug }}.pdf">get
     the pdf</a>{% endif %}


### PR DESCRIPTION
We want to populate various HTML metatags from pelican. The data is there, we just have to put in HTML!

To be more precise, the meta names "keywords", "category", "description", "author", "robots" and "date" are taken from pelican variables.