### PR TITLE
Fix new-bootstrap2 tagcloud + making feed_atom optional in sidebar

### DIFF
--- a/new-bootstrap2/templates/sidebar.html
+++ b/new-bootstrap2/templates/sidebar.html
@@ -7,7 +7,9 @@
 {% endif %}
 {% if SOCIAL %}
 <li class="nav-header"><h4><i class="icon-home icon-large"></i> social</h4></li>
+{% if FEED_ATOM %}
 <li><a href="{{ SITEURL }}/{{ FEED_ATOM }}" rel="alternate"><i class="icon-bookmark icon-large"></i>atom feed</a></li>
+{% endif %}
 {% if FEED_RSS %}
 <li><a href="{{ SITEURL }}/{{ FEED_RSS }}" rel="alternate"><i class="icon-bookmark icon-large"></i>rss feed</a></li>
 {% endif %}
@@ -25,6 +27,7 @@
 </li>
 {% endfor %}
 
+{% if 'tag_cloud' in PLUGINS %}
 <li class="nav-header"><a href="{{ SITEURL }}/tags.html"><h4><i class="icon-tags icon-large"></i>Tags</h4></a></li>
 {# <li>
 <div id="tags">
@@ -36,6 +39,7 @@
         </a>
     </li>
 {% endfor %}
+{% endif %}
 {#  </ul>
 </div>
 <div id="myCanvasContainer">


### PR DESCRIPTION
Tagcloud has been moved out to a plugin and is no longer included in the core. This commit checks before generating a tagcloud. Additionally it makes the feed_atom disappear if there's no intent to generate an Atom feed.

Please merge - Thank you!
Pfuender