### PR TITLE
Use HTTPS for Disqus requests

### DIFF
--- a/Just-Read/templates/article.html
+++ b/Just-Read/templates/article.html
@@ -18,7 +18,7 @@
 			       var disqus_identifier = "{{ article.url }}";
 			       (function() {
 			       var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;
-			       dsq.src = '//{{ DISQUS_SITENAME }}.disqus.com/embed.js';
+			       dsq.src = 'https://{{ DISQUS_SITENAME }}.disqus.com/embed.js';
 			       (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);
 			      })();
 			    </script>

--- a/SoMA/templates/article.html
+++ b/SoMA/templates/article.html
@@ -24,7 +24,7 @@
             var disqus_identifier = "{{ article.url }}";
             (function() {
             var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;
-            dsq.src = 'http://{{ DISQUS_SITENAME }}.disqus.com/embed.js';
+            dsq.src = '//{{ DISQUS_SITENAME }}.disqus.com/embed.js';
             (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);
             })();
           </script>

--- a/SoMA/templates/article.html
+++ b/SoMA/templates/article.html
@@ -24,7 +24,7 @@
             var disqus_identifier = "{{ article.url }}";
             (function() {
             var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;
-            dsq.src = '//{{ DISQUS_SITENAME }}.disqus.com/embed.js';
+            dsq.src = 'https://{{ DISQUS_SITENAME }}.disqus.com/embed.js';
             (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);
             })();
           </script>

--- a/SoMA2/templates/article.html
+++ b/SoMA2/templates/article.html
@@ -24,7 +24,7 @@
             var disqus_identifier = "{{ article.url }}";
             (function() {
             var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;
-            dsq.src = 'http://{{ DISQUS_SITENAME }}.disqus.com/embed.js';
+            dsq.src = '//{{ DISQUS_SITENAME }}.disqus.com/embed.js';
             (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);
             })();
           </script>

--- a/SoMA2/templates/article.html
+++ b/SoMA2/templates/article.html
@@ -24,7 +24,7 @@
             var disqus_identifier = "{{ article.url }}";
             (function() {
             var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;
-            dsq.src = '//{{ DISQUS_SITENAME }}.disqus.com/embed.js';
+            dsq.src = 'https://{{ DISQUS_SITENAME }}.disqus.com/embed.js';
             (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);
             })();
           </script>

--- a/aboutwilson/templates/disqus.html
+++ b/aboutwilson/templates/disqus.html
@@ -6,7 +6,7 @@
 
     (function() {
         var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;
-        dsq.src = '//' + disqus_shortname + '.disqus.com/embed.js';
+        dsq.src = 'https://' + disqus_shortname + '.disqus.com/embed.js';
         (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);
     })();
 </script>

--- a/aboutwilson/templates/disqus.html
+++ b/aboutwilson/templates/disqus.html
@@ -6,7 +6,7 @@
 
     (function() {
         var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;
-        dsq.src = 'http://' + disqus_shortname + '.disqus.com/embed.js';
+        dsq.src = '//' + disqus_shortname + '.disqus.com/embed.js';
         (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);
     })();
 </script>

--- a/backdrop/templates/article.html
+++ b/backdrop/templates/article.html
@@ -29,7 +29,7 @@
             /* * * DON'T EDIT BELOW THIS LINE * * */
             (function() {
                 var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;
-                dsq.src = '//' + disqus_shortname + '.disqus.com/embed.js';
+                dsq.src = 'https://' + disqus_shortname + '.disqus.com/embed.js';
                 (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);
             })();
         </script>

--- a/bootlex/templates/article.html
+++ b/bootlex/templates/article.html
@@ -18,7 +18,7 @@
             /* * * DON'T EDIT BELOW THIS LINE * * */
             (function() {
                 var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;
-                dsq.src = '//' + disqus_shortname + '.disqus.com/embed.js';
+                dsq.src = 'https://' + disqus_shortname + '.disqus.com/embed.js';
                 (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);
             })();
         </script>

--- a/bootlex/templates/article.html
+++ b/bootlex/templates/article.html
@@ -18,7 +18,7 @@
             /* * * DON'T EDIT BELOW THIS LINE * * */
             (function() {
                 var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;
-                dsq.src = 'http://' + disqus_shortname + '.disqus.com/embed.js';
+                dsq.src = '//' + disqus_shortname + '.disqus.com/embed.js';
                 (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);
             })();
         </script>

--- a/bootstrap/templates/disqus.html
+++ b/bootstrap/templates/disqus.html
@@ -3,7 +3,7 @@
 	var disqus_identifier = "{{ article.url }}";
 	(function() {
 		var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;
-		dsq.src = '//{{ DISQUS_SITENAME }}.disqus.com/embed.js';
+		dsq.src = 'https://{{ DISQUS_SITENAME }}.disqus.com/embed.js';
 		(document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);
 	})();
 </script>

--- a/bootstrap/templates/disqus.html
+++ b/bootstrap/templates/disqus.html
@@ -3,7 +3,7 @@
 	var disqus_identifier = "{{ article.url }}";
 	(function() {
 		var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;
-		dsq.src = 'http://{{ DISQUS_SITENAME }}.disqus.com/embed.js';
+		dsq.src = '//{{ DISQUS_SITENAME }}.disqus.com/embed.js';
 		(document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);
 	})();
 </script>

--- a/bootstrap2-dark/templates/article.html
+++ b/bootstrap2-dark/templates/article.html
@@ -28,7 +28,7 @@
                            (function() {
                                 var dsq = document.createElement('script');
                                 dsq.type = 'text/javascript'; dsq.async = true;
-                                dsq.src = 'http://{{ DISQUS_SITENAME }}.disqus.com/embed.js';
+                                dsq.src = '//{{ DISQUS_SITENAME }}.disqus.com/embed.js';
                                 (document.getElementsByTagName('head')[0] ||
                                  document.getElementsByTagName('body')[0]).appendChild(dsq);
                           })();

--- a/bootstrap2-dark/templates/article.html
+++ b/bootstrap2-dark/templates/article.html
@@ -28,7 +28,7 @@
                            (function() {
                                 var dsq = document.createElement('script');
                                 dsq.type = 'text/javascript'; dsq.async = true;
-                                dsq.src = '//{{ DISQUS_SITENAME }}.disqus.com/embed.js';
+                                dsq.src = 'https://{{ DISQUS_SITENAME }}.disqus.com/embed.js';
                                 (document.getElementsByTagName('head')[0] ||
                                  document.getElementsByTagName('body')[0]).appendChild(dsq);
                           })();

--- a/bootstrap2/templates/article.html
+++ b/bootstrap2/templates/article.html
@@ -28,7 +28,7 @@
                            (function() {
                                 var dsq = document.createElement('script');
                                 dsq.type = 'text/javascript'; dsq.async = true;
-                                dsq.src = 'http://{{ DISQUS_SITENAME }}.disqus.com/embed.js';
+                                dsq.src = '//{{ DISQUS_SITENAME }}.disqus.com/embed.js';
                                 (document.getElementsByTagName('head')[0] ||
                                  document.getElementsByTagName('body')[0]).appendChild(dsq);
                           })();

--- a/bootstrap2/templates/article.html
+++ b/bootstrap2/templates/article.html
@@ -28,7 +28,7 @@
                            (function() {
                                 var dsq = document.createElement('script');
                                 dsq.type = 'text/javascript'; dsq.async = true;
-                                dsq.src = '//{{ DISQUS_SITENAME }}.disqus.com/embed.js';
+                                dsq.src = 'https://{{ DISQUS_SITENAME }}.disqus.com/embed.js';
                                 (document.getElementsByTagName('head')[0] ||
                                  document.getElementsByTagName('body')[0]).appendChild(dsq);
                           })();

--- a/bricks/templates/article_discus.html
+++ b/bricks/templates/article_discus.html
@@ -10,7 +10,7 @@
             /* * * DON'T EDIT BELOW THIS LINE * * */
             (function() {
                 var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;
-                dsq.src = '//' + disqus_shortname + '.disqus.com/embed.js';
+                dsq.src = 'https://' + disqus_shortname + '.disqus.com/embed.js';
                 (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);
             })();
         </script>

--- a/brownstone/templates/article.html
+++ b/brownstone/templates/article.html
@@ -24,7 +24,7 @@
                                                var disqus_identifier = "{{ article.url }}";
                                                (function() {
                                                var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;
-                                               dsq.src = 'http://{{ DISQUS_SITENAME }}.disqus.com/embed.js';
+                                               dsq.src = '//{{ DISQUS_SITENAME }}.disqus.com/embed.js';
                                                (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);
                                               })();
                                             </script>

--- a/brownstone/templates/article.html
+++ b/brownstone/templates/article.html
@@ -24,7 +24,7 @@
                                                var disqus_identifier = "{{ article.url }}";
                                                (function() {
                                                var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;
-                                               dsq.src = '//{{ DISQUS_SITENAME }}.disqus.com/embed.js';
+                                               dsq.src = 'https://{{ DISQUS_SITENAME }}.disqus.com/embed.js';
                                                (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);
                                               })();
                                             </script>

--- a/built-texts/templates/disqus.html
+++ b/built-texts/templates/disqus.html
@@ -5,7 +5,7 @@
 
     (function() {
         var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;
-        dsq.src = 'https://' + disqus_shortname + '.disqus.com/embed.js';
+        dsq.src = '//' + disqus_shortname + '.disqus.com/embed.js';
         (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);
     })();
 </script>

--- a/built-texts/templates/disqus.html
+++ b/built-texts/templates/disqus.html
@@ -5,7 +5,7 @@
 
     (function() {
         var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;
-        dsq.src = '//' + disqus_shortname + '.disqus.com/embed.js';
+        dsq.src = 'https://' + disqus_shortname + '.disqus.com/embed.js';
         (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);
     })();
 </script>

--- a/cebong/templates/article.html
+++ b/cebong/templates/article.html
@@ -50,7 +50,7 @@
         var disqus_identifier = "{{ article.url }}";
         (function() {
         var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;
-        dsq.src = 'https://{{ DISQUS_SITENAME }}.disqus.com/embed.js';
+        dsq.src = '//{{ DISQUS_SITENAME }}.disqus.com/embed.js';
         (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);
         })();
       </script>

--- a/cebong/templates/article.html
+++ b/cebong/templates/article.html
@@ -50,7 +50,7 @@
         var disqus_identifier = "{{ article.url }}";
         (function() {
         var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;
-        dsq.src = '//{{ DISQUS_SITENAME }}.disqus.com/embed.js';
+        dsq.src = 'https://{{ DISQUS_SITENAME }}.disqus.com/embed.js';
         (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);
         })();
       </script>

--- a/dev-random/templates/article.html
+++ b/dev-random/templates/article.html
@@ -54,7 +54,7 @@
             /* * * DON'T EDIT BELOW THIS LINE * * */
             (function() {
                 var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;
-                dsq.src = '//' + disqus_shortname + '.disqus.com/embed.js';
+                dsq.src = 'https://' + disqus_shortname + '.disqus.com/embed.js';
                 (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);
             })();
         </script>

--- a/dev-random/templates/article.html
+++ b/dev-random/templates/article.html
@@ -54,7 +54,7 @@
             /* * * DON'T EDIT BELOW THIS LINE * * */
             (function() {
                 var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;
-                dsq.src = 'http://' + disqus_shortname + '.disqus.com/embed.js';
+                dsq.src = '//' + disqus_shortname + '.disqus.com/embed.js';
                 (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);
             })();
         </script>

--- a/dev-random2/templates/article.html
+++ b/dev-random2/templates/article.html
@@ -43,7 +43,7 @@
             /* * * DON'T EDIT BELOW THIS LINE * * */
             (function() {
                 var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;
-                dsq.src = 'http://' + disqus_shortname + '.disqus.com/embed.js';
+                dsq.src = '//' + disqus_shortname + '.disqus.com/embed.js';
                 (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);
             })();
         </script>

--- a/dev-random2/templates/article.html
+++ b/dev-random2/templates/article.html
@@ -43,7 +43,7 @@
             /* * * DON'T EDIT BELOW THIS LINE * * */
             (function() {
                 var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;
-                dsq.src = '//' + disqus_shortname + '.disqus.com/embed.js';
+                dsq.src = 'https://' + disqus_shortname + '.disqus.com/embed.js';
                 (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);
             })();
         </script>

--- a/foundation-default-colours/templates/article.html
+++ b/foundation-default-colours/templates/article.html
@@ -18,7 +18,7 @@
 			var disqus_shortname = '{{ DISQUS_SITENAME }}';
 			(function() {
 				var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;
-				dsq.src = '//' + disqus_shortname + '.disqus.com/embed.js';
+				dsq.src = 'https://' + disqus_shortname + '.disqus.com/embed.js';
 				(document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);
 			})();
 		</script>

--- a/franticworld/templates/article.html
+++ b/franticworld/templates/article.html
@@ -21,7 +21,7 @@
 	   (function() {
 			var dsq = document.createElement('script');
 			dsq.type = 'text/javascript'; dsq.async = true;
-			dsq.src = 'http://{{ DISQUS_SITENAME }}.disqus.com/embed.js';
+			dsq.src = '//{{ DISQUS_SITENAME }}.disqus.com/embed.js';
 			(document.getElementsByTagName('head')[0] ||
 			 document.getElementsByTagName('body')[0]).appendChild(dsq);
 	  })();

--- a/franticworld/templates/article.html
+++ b/franticworld/templates/article.html
@@ -21,7 +21,7 @@
 	   (function() {
 			var dsq = document.createElement('script');
 			dsq.type = 'text/javascript'; dsq.async = true;
-			dsq.src = '//{{ DISQUS_SITENAME }}.disqus.com/embed.js';
+			dsq.src = 'https://{{ DISQUS_SITENAME }}.disqus.com/embed.js';
 			(document.getElementsByTagName('head')[0] ||
 			 document.getElementsByTagName('body')[0]).appendChild(dsq);
 	  })();

--- a/franticworld/templates/page.html
+++ b/franticworld/templates/page.html
@@ -13,7 +13,7 @@
 		   (function() {
 				var dsq = document.createElement('script');
 				dsq.type = 'text/javascript'; dsq.async = true;
-				dsq.src = '//{{ DISQUS_SITENAME }}.disqus.com/embed.js';
+				dsq.src = 'https://{{ DISQUS_SITENAME }}.disqus.com/embed.js';
 				(document.getElementsByTagName('head')[0] ||
 				 document.getElementsByTagName('body')[0]).appendChild(dsq);
 		  })();

--- a/franticworld/templates/page.html
+++ b/franticworld/templates/page.html
@@ -13,7 +13,7 @@
 		   (function() {
 				var dsq = document.createElement('script');
 				dsq.type = 'text/javascript'; dsq.async = true;
-				dsq.src = 'http://{{ DISQUS_SITENAME }}.disqus.com/embed.js';
+				dsq.src = '//{{ DISQUS_SITENAME }}.disqus.com/embed.js';
 				(document.getElementsByTagName('head')[0] ||
 				 document.getElementsByTagName('body')[0]).appendChild(dsq);
 		  })();

--- a/gum/templates/article.html
+++ b/gum/templates/article.html
@@ -37,7 +37,7 @@
                 var disqus_identifier = "{{ article.url }}";
                 (function() {
                 var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;
-                dsq.src = '//{{ DISQUS_SITENAME }}.disqus.com/embed.js';
+                dsq.src = 'https://{{ DISQUS_SITENAME }}.disqus.com/embed.js';
                 (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);
                 })();
               </script>

--- a/gum/templates/article.html
+++ b/gum/templates/article.html
@@ -37,7 +37,7 @@
                 var disqus_identifier = "{{ article.url }}";
                 (function() {
                 var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;
-                dsq.src = 'http://{{ DISQUS_SITENAME }}.disqus.com/embed.js';
+                dsq.src = '//{{ DISQUS_SITENAME }}.disqus.com/embed.js';
                 (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);
                 })();
               </script>

--- a/lightweight/templates/article.html
+++ b/lightweight/templates/article.html
@@ -21,7 +21,7 @@
                var disqus_identifier = "{{ article.url }}";
                (function() {
                var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;
-               dsq.src = 'http://{{ DISQUS_SITENAME }}.disqus.com/embed.js';
+               dsq.src = '//{{ DISQUS_SITENAME }}.disqus.com/embed.js';
                (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);
               })();
             </script>

--- a/lightweight/templates/article.html
+++ b/lightweight/templates/article.html
@@ -21,7 +21,7 @@
                var disqus_identifier = "{{ article.url }}";
                (function() {
                var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;
-               dsq.src = '//{{ DISQUS_SITENAME }}.disqus.com/embed.js';
+               dsq.src = 'https://{{ DISQUS_SITENAME }}.disqus.com/embed.js';
                (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);
               })();
             </script>

--- a/monospace/templates/article.html
+++ b/monospace/templates/article.html
@@ -18,7 +18,7 @@
        (function() {
             var dsq = document.createElement('script');
             dsq.type = 'text/javascript'; dsq.async = true;
-            dsq.src = 'http://' + disqus_shortname + '.disqus.com/embed.js';
+            dsq.src = '//' + disqus_shortname + '.disqus.com/embed.js';
             (document.getElementsByTagName('head')[0] ||
              document.getElementsByTagName('body')[0]).appendChild(dsq);
       })();

--- a/monospace/templates/article.html
+++ b/monospace/templates/article.html
@@ -18,7 +18,7 @@
        (function() {
             var dsq = document.createElement('script');
             dsq.type = 'text/javascript'; dsq.async = true;
-            dsq.src = '//' + disqus_shortname + '.disqus.com/embed.js';
+            dsq.src = 'https://' + disqus_shortname + '.disqus.com/embed.js';
             (document.getElementsByTagName('head')[0] ||
              document.getElementsByTagName('body')[0]).appendChild(dsq);
       })();

--- a/new-bootstrap2/templates/article.html
+++ b/new-bootstrap2/templates/article.html
@@ -33,7 +33,7 @@
                (function() {
                     var dsq = document.createElement('script');
                     dsq.type = 'text/javascript'; dsq.async = true;
-                    dsq.src = '//{{ DISQUS_SITENAME }}.disqus.com/embed.js';
+                    dsq.src = 'https://{{ DISQUS_SITENAME }}.disqus.com/embed.js';
                     (document.getElementsByTagName('head')[0] ||
                      document.getElementsByTagName('body')[0]).appendChild(dsq);
               })();

--- a/new-bootstrap2/templates/article.html
+++ b/new-bootstrap2/templates/article.html
@@ -33,7 +33,7 @@
                (function() {
                     var dsq = document.createElement('script');
                     dsq.type = 'text/javascript'; dsq.async = true;
-                    dsq.src = 'http://{{ DISQUS_SITENAME }}.disqus.com/embed.js';
+                    dsq.src = '//{{ DISQUS_SITENAME }}.disqus.com/embed.js';
                     (document.getElementsByTagName('head')[0] ||
                      document.getElementsByTagName('body')[0]).appendChild(dsq);
               })();

--- a/new-bootstrap2/templates/disqus_script.html
+++ b/new-bootstrap2/templates/disqus_script.html
@@ -7,7 +7,7 @@
     /* * * DON'T EDIT BELOW THIS LINE * * */
     (function() {
         var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;
-        dsq.src = 'http://' + disqus_shortname + '.disqus.com/embed.js';
+        dsq.src = '//' + disqus_shortname + '.disqus.com/embed.js';
         (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);
     })();
 </script>

--- a/new-bootstrap2/templates/disqus_script.html
+++ b/new-bootstrap2/templates/disqus_script.html
@@ -7,7 +7,7 @@
     /* * * DON'T EDIT BELOW THIS LINE * * */
     (function() {
         var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;
-        dsq.src = '//' + disqus_shortname + '.disqus.com/embed.js';
+        dsq.src = 'https://' + disqus_shortname + '.disqus.com/embed.js';
         (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);
     })();
 </script>

--- a/notebook/templates/article.html
+++ b/notebook/templates/article.html
@@ -55,7 +55,7 @@
             (function() {
                 var dsq = document.createElement('script');
                 dsq.type = 'text/javascript'; dsq.async = true;
-                dsq.src = 'http://{{ DISQUS_SITENAME }}.disqus.com/embed.js';
+                dsq.src = '//{{ DISQUS_SITENAME }}.disqus.com/embed.js';
                 (document.getElementsByTagName('head')[0] ||
                  document.getElementsByTagName('body')[0]).appendChild(dsq);
             })();

--- a/notebook/templates/article.html
+++ b/notebook/templates/article.html
@@ -55,7 +55,7 @@
             (function() {
                 var dsq = document.createElement('script');
                 dsq.type = 'text/javascript'; dsq.async = true;
-                dsq.src = '//{{ DISQUS_SITENAME }}.disqus.com/embed.js';
+                dsq.src = 'https://{{ DISQUS_SITENAME }}.disqus.com/embed.js';
                 (document.getElementsByTagName('head')[0] ||
                  document.getElementsByTagName('body')[0]).appendChild(dsq);
             })();

--- a/notmyidea-cms-fr/templates/article.html
+++ b/notmyidea-cms-fr/templates/article.html
@@ -29,7 +29,7 @@
                var disqus_identifier = "{{ article.url }}";
                (function() {
                var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;
-               dsq.src = '//{{ DISQUS_SITENAME }}.disqus.com/embed.js';
+               dsq.src = 'https://{{ DISQUS_SITENAME }}.disqus.com/embed.js';
                (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);
               })();
             </script>

--- a/notmyidea-cms-fr/templates/article.html
+++ b/notmyidea-cms-fr/templates/article.html
@@ -29,7 +29,7 @@
                var disqus_identifier = "{{ article.url }}";
                (function() {
                var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;
-               dsq.src = 'http://{{ DISQUS_SITENAME }}.disqus.com/embed.js';
+               dsq.src = '//{{ DISQUS_SITENAME }}.disqus.com/embed.js';
                (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);
               })();
             </script>

--- a/notmyidea-cms/templates/article.html
+++ b/notmyidea-cms/templates/article.html
@@ -18,7 +18,7 @@
                var disqus_identifier = "{{ article.url }}";
                (function() {
                var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;
-               dsq.src = 'http://{{ DISQUS_SITENAME }}.disqus.com/embed.js';
+               dsq.src = '//{{ DISQUS_SITENAME }}.disqus.com/embed.js';
                (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);
               })();
             </script>

--- a/notmyidea-cms/templates/article.html
+++ b/notmyidea-cms/templates/article.html
@@ -18,7 +18,7 @@
                var disqus_identifier = "{{ article.url }}";
                (function() {
                var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;
-               dsq.src = '//{{ DISQUS_SITENAME }}.disqus.com/embed.js';
+               dsq.src = 'https://{{ DISQUS_SITENAME }}.disqus.com/embed.js';
                (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);
               })();
             </script>

--- a/pelican-bootstrap3/templates/includes/comments.html
+++ b/pelican-bootstrap3/templates/includes/comments.html
@@ -29,7 +29,7 @@
                 var dsq = document.createElement('script');
                 dsq.type = 'text/javascript';
                 dsq.async = true;
-                dsq.src = '//' + disqus_shortname + '.disqus.com/embed.js';
+                dsq.src = 'https://' + disqus_shortname + '.disqus.com/embed.js';
                 (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);
             })();
         </script>

--- a/photowall/templates/article.html
+++ b/photowall/templates/article.html
@@ -58,7 +58,7 @@
         var disqus_url = '{{ SITEURL }}/{{ article.url }}';
         (function() {
         var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;
-        dsq.src = '//{{ DISQUS_SITENAME }}.disqus.com/embed.js';
+        dsq.src = 'https://{{ DISQUS_SITENAME }}.disqus.com/embed.js';
         (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);
         })();
       </script>

--- a/simple-bootstrap/templates/article.html
+++ b/simple-bootstrap/templates/article.html
@@ -36,7 +36,7 @@
         /* * * DON'T EDIT BELOW THIS LINE * * */
         (function() {
             var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;
-            dsq.src = '//' + disqus_shortname + '.disqus.com/embed.js';
+            dsq.src = 'https://' + disqus_shortname + '.disqus.com/embed.js';
             (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);
         })();
     </script>

--- a/sneakyidea/templates/article.html
+++ b/sneakyidea/templates/article.html
@@ -19,7 +19,7 @@
                var disqus_identifier = "{{ article.url }}";
                (function() {
                var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;
-               dsq.src = '//{{ DISQUS_SITENAME }}.disqus.com/embed.js';
+               dsq.src = 'https://{{ DISQUS_SITENAME }}.disqus.com/embed.js';
                (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);
               })();
             </script>

--- a/sneakyidea/templates/article.html
+++ b/sneakyidea/templates/article.html
@@ -19,7 +19,7 @@
                var disqus_identifier = "{{ article.url }}";
                (function() {
                var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;
-               dsq.src = 'http://{{ DISQUS_SITENAME }}.disqus.com/embed.js';
+               dsq.src = '//{{ DISQUS_SITENAME }}.disqus.com/embed.js';
                (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);
               })();
             </script>

--- a/subtle/templates/article.html
+++ b/subtle/templates/article.html
@@ -22,7 +22,7 @@
         var disqus_identifier = "{{ article.url }}";
         (function() {
         var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;
-        dsq.src = 'http://{{ DISQUS_SITENAME }}.disqus.com/embed.js';
+        dsq.src = '//{{ DISQUS_SITENAME }}.disqus.com/embed.js';
         (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);
         })();
       </script>

--- a/subtle/templates/article.html
+++ b/subtle/templates/article.html
@@ -22,7 +22,7 @@
         var disqus_identifier = "{{ article.url }}";
         (function() {
         var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;
-        dsq.src = '//{{ DISQUS_SITENAME }}.disqus.com/embed.js';
+        dsq.src = 'https://{{ DISQUS_SITENAME }}.disqus.com/embed.js';
         (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);
         })();
       </script>

--- a/syte/templates/article.html
+++ b/syte/templates/article.html
@@ -41,7 +41,7 @@
 					var disqus_identifier = "{{ article.url }}";
 					(function() {
 					 var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;
-					 dsq.src = 'http://{{ DISQUS_SITENAME }}.disqus.com/embed.js';
+					 dsq.src = '//{{ DISQUS_SITENAME }}.disqus.com/embed.js';
 					 (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);
 					 })();
 			 </script>

--- a/syte/templates/article.html
+++ b/syte/templates/article.html
@@ -41,7 +41,7 @@
 					var disqus_identifier = "{{ article.url }}";
 					(function() {
 					 var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;
-					 dsq.src = '//{{ DISQUS_SITENAME }}.disqus.com/embed.js';
+					 dsq.src = 'https://{{ DISQUS_SITENAME }}.disqus.com/embed.js';
 					 (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);
 					 })();
 			 </script>

--- a/tuxlite_tbs/templates/disqus.html
+++ b/tuxlite_tbs/templates/disqus.html
@@ -6,7 +6,7 @@
 
     (function() {
         var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;
-        dsq.src = '//' + disqus_shortname + '.disqus.com/embed.js';
+        dsq.src = 'https://' + disqus_shortname + '.disqus.com/embed.js';
         (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);
     })();
 </script>

--- a/tuxlite_tbs/templates/disqus.html
+++ b/tuxlite_tbs/templates/disqus.html
@@ -6,7 +6,7 @@
 
     (function() {
         var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;
-        dsq.src = 'http://' + disqus_shortname + '.disqus.com/embed.js';
+        dsq.src = '//' + disqus_shortname + '.disqus.com/embed.js';
         (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);
     })();
 </script>

--- a/tuxlite_zf/templates/disqus_script.html
+++ b/tuxlite_zf/templates/disqus_script.html
@@ -7,7 +7,7 @@
 
         (function() {
             var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;
-            dsq.src = '//' + disqus_shortname + '.disqus.com/embed.js';
+            dsq.src = 'https://' + disqus_shortname + '.disqus.com/embed.js';
             (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);
         })();
     </script>

--- a/waterspill-en/templates/article.html
+++ b/waterspill-en/templates/article.html
@@ -26,7 +26,7 @@
        var disqus_identifier = "{{ article.url }}";
        (function() {
        var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;
-       dsq.src = '//{{ DISQUS_SITENAME }}.disqus.com/embed.js';
+       dsq.src = 'https://{{ DISQUS_SITENAME }}.disqus.com/embed.js';
        (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);
       })();
     </script>

--- a/waterspill-en/templates/article.html
+++ b/waterspill-en/templates/article.html
@@ -26,7 +26,7 @@
        var disqus_identifier = "{{ article.url }}";
        (function() {
        var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;
-       dsq.src = 'http://{{ DISQUS_SITENAME }}.disqus.com/embed.js';
+       dsq.src = '//{{ DISQUS_SITENAME }}.disqus.com/embed.js';
        (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);
       })();
     </script>

--- a/waterspill/templates/article.html
+++ b/waterspill/templates/article.html
@@ -26,7 +26,7 @@
        var disqus_identifier = "{{ article.url }}";
        (function() {
        var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;
-       dsq.src = '//{{ DISQUS_SITENAME }}.disqus.com/embed.js';
+       dsq.src = 'https://{{ DISQUS_SITENAME }}.disqus.com/embed.js';
        (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);
       })();
     </script>

--- a/waterspill/templates/article.html
+++ b/waterspill/templates/article.html
@@ -26,7 +26,7 @@
        var disqus_identifier = "{{ article.url }}";
        (function() {
        var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;
-       dsq.src = 'http://{{ DISQUS_SITENAME }}.disqus.com/embed.js';
+       dsq.src = '//{{ DISQUS_SITENAME }}.disqus.com/embed.js';
        (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);
       })();
     </script>

--- a/zurb-F5-basic/templates/disqus_script.html
+++ b/zurb-F5-basic/templates/disqus_script.html
@@ -7,7 +7,7 @@
 
         (function() {
             var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;
-            dsq.src = '//' + disqus_shortname + '.disqus.com/embed.js';
+            dsq.src = 'https://' + disqus_shortname + '.disqus.com/embed.js';
             (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);
         })();
     </script>


### PR DESCRIPTION
# The problem
Disqus does not load from `https://` sites under the `gum` theme (and almost any other). This happens because the Disqus URL prefix is `http://`, and insecure content will not be loaded from a secure site.

# The solution

## Disqus documentation
According to the [official Disqus documentation](https://disqus.com/admin/universalcode/), the embed code source should use Protocol-relative URL:

    s.src = '//XXXXX.disqus.com/embed.js';

While themes use:

    s.src = 'http://XXXXX.disqus.com/embed.js';
    s.src = 'https://XXXXX.disqus.com/embed.js';

Where `XXXXX` is the Disqus site name, denoted `{{ DISQUS_SITENAME }}` in Pelican.

## My solution

I've converted both `http://` and `https://` prefixes to the https, which will only work. Following comments on this thread, I decided to avoid [Protocol-Relative URLs](https://en.wikipedia.org/wiki/Uniform_Resource_Locator#Protocol-relative_URLs) and just go secure in every call.

See further discussion here: https://github.com/getpelican/pelican/issues/1911