### PR TITLE
More tuxlite_tbs improvements

### DIFF
--- a/tuxlite_tbs/templates/author.html
+++ b/tuxlite_tbs/templates/author.html
@@ -1,2 +1,2 @@
 {% extends "index.html" %}
-{% block title %}{{ SITENAME }} <small>{{ author }}</small>{% endblock %}
+{% block title %}{{ SITENAME }} - {{ author }}{% endblock %}

--- a/tuxlite_tbs/templates/categories.html
+++ b/tuxlite_tbs/templates/categories.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% block title %}{{ SITENAME }} <small>[categories]</small>{% endblock %}
+{% block title %}{{ SITENAME }} - [categories]{% endblock %}
 {% block content %}
 <ul>
 {% for category, articles in categories %}

--- a/tuxlite_tbs/templates/tag.html
+++ b/tuxlite_tbs/templates/tag.html
@@ -1,2 +1,2 @@
 {% extends "index.html" %}
-{% block title %}{{ SITENAME }} <small>{{ tag }}</small>{% endblock %}
+{% block title %}{{ SITENAME }} - {{ tag }}{% endblock %}

--- a/tuxlite_tbs/templates/twitter.html
+++ b/tuxlite_tbs/templates/twitter.html
@@ -1,4 +1,4 @@
 {% if TWITTER_USERNAME %}
-<a href="https://twitter.com/share" class="twitter-share-button" data-via="{{TWITTER_USERNAME}}">Tweet</a>
+<a href="https://twitter.com/share" class="twitter-share-button" data-text="{{article.title}}" data-via="{{TWITTER_USERNAME}}">Tweet</a>
 <script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],p=/^http:/.test(d.location)?'http':'https';if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src=p+'://platform.twitter.com/widgets.js';fjs.parentNode.insertBefore(js,fjs);}}(document, 'script', 'twitter-wjs');</script>
 {% endif %}

--- a/tuxlite_tbs/templates/twitter.html
+++ b/tuxlite_tbs/templates/twitter.html
@@ -1,3 +1,4 @@
 {% if TWITTER_USERNAME %}
-<a href="http://twitter.com/share" class="twitter-share-button" data-count="horizontal" data-text="{{article.title}}" data-via="{{TWITTER_USERNAME}}">Tweet</a><script type="text/javascript" src="http://platform.twitter.com/widgets.js"></script>
+<a href="https://twitter.com/share" class="twitter-share-button" data-via="{{TWITTER_USERNAME}}">Tweet</a>
+<script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],p=/^http:/.test(d.location)?'http':'https';if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src=p+'://platform.twitter.com/widgets.js';fjs.parentNode.insertBefore(js,fjs);}}(document, 'script', 'twitter-wjs');</script>
 {% endif %}


### PR DESCRIPTION
Fix previously missed templates that also had the odd <small> tags

Update twitter template to match current twitter docs

When users click twitter button to post link to twitter it should only include the article title, not the site name