### PR TITLE
new-bootstrap2: Honor "ARCHIVE_URL" in base template

### DIFF
--- a/new-bootstrap2/templates/base.html
+++ b/new-bootstrap2/templates/base.html
@@ -82,7 +82,7 @@
                 </li>
               {% endfor %}
               <ul class="nav pull-right">
-                    <li><a href="{{ SITEURL }}/archives.html"><i class="icon-th-list"></i>Archives</a></li>
+                    <li><a href="{{ SITEURL }}/{{ ARCHIVES_URL }}"><i class="icon-th-list"></i>Archives</a></li>
               </ul>
 
             </ul>


### PR DESCRIPTION
new-bootstrap2 doesn't honor the "ARCHIVE_URL" location, this fixes that.