### PR TITLE
pelican-bootstrap3: Add sidebar image header

### DIFF
--- a/pelican-bootstrap3/README.md
+++ b/pelican-bootstrap3/README.md
@@ -293,9 +293,14 @@ The footer will display a copyright message using the AUTHOR variable and the ye
 
 ### Sidebar Images
 
-Include a series of images in the sidebar.
+Include a series of images in the sidebar, with an optional header:
 
+SIDEBAR_IMAGES_HEADER = 'My Images'
 SIDEBAR_IMAGES = ["/path/to/image1.png", "/path/to/image2.png"]
+
+Originally developed for including certification marks in your sidebar. E.g.,
+
+http://dmark.github.io
 
 ## Live example
 

--- a/pelican-bootstrap3/templates/includes/sidebar-images.html
+++ b/pelican-bootstrap3/templates/includes/sidebar-images.html
@@ -1,4 +1,7 @@
 {% if SIDEBAR_IMAGES %}
+    {% if SIDEBAR_IMAGES_HEADER %}
+        <li class="list-group-item"><h4><i class="fa fa-external-link-square fa-lg"></i><span class="icon-label">{{ SIDEBAR_IMAGES_HEADER }}</span></h4>
+    {% endif %}
     <li class="list-group-item">
         <ul class="list-group" id="links">
         {% for image in SIDEBAR_IMAGES %}


### PR DESCRIPTION
Adds a header above the sidebar images, if any. Live example: http://dmark.github.io/.