### PR TITLE
monospace: link to page.url, not page.slug

### DIFF
--- a/monospace/templates/page.html
+++ b/monospace/templates/page.html
@@ -3,7 +3,7 @@
 {% block content %}        
 <header>
 <h1><a href="{{ SITEURL }}" id="site-title">{# {{ SITENAME }} #} {% if SITESUBTITLE %} <strong>{{ SITESUBTITLE }}</strong>{% endif %}</a> {#:#}
-        <a href="{{ SITEURL }}/{{ page.slug }}" id="page-title">{{ page.title }}</a></h1>
+        <a href="{{ SITEURL }}/{{ page.url }}" id="page-title">{{ page.title }}</a></h1>
 </header>
 <article>    
     {{ page.content }}


### PR DESCRIPTION
The page template in monospace should link against ```{{SITEURL}}/{{page.url}}```, not ```{{SITEURL}}/page.slug}}```. Otherwise the links to the pages that get created won't work (they'll point at /pagename.html instead of /pages/pagename.html).