### PR TITLE
Update remotes for octopress and delete pelipress

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -85,9 +85,6 @@
 [submodule "jesuislibre"]
 	path = jesuislibre
 	url = https://github.com/badele/pelican-theme-jesuislibre.git
-[submodule "pelipress"]
-	path = pelipress
-	url = https://github.com/jjimenezlopez/pelipress.git
 [submodule "blueidea"]
 	path = blueidea
 	url = https://github.com/blueicefield/pelican-blueidea.git
@@ -168,7 +165,7 @@
 	url = https://github.com/abr4xas/Casper2Pelican.git
 [submodule "octopress"]
 	path = octopress
-	url = https://github.com/duilio/pelican-octopress-theme.git
+	url = https://github.com/MrSenko/pelican-octopress-theme
 [submodule "smoothie"]
 	path = smoothie
 	url = https://github.com/kdheepak89/pelican-smoothie.git


### PR DESCRIPTION
Both pelican-octopress-theme and pelipress seem to have been
abandoned. MrSenko/pelican-octopress-theme is a fork which has
merged all pending PRs from the original repo and also added
the functionality originally developed by pelipress.
