### PR TITLE
Fix year in aboutwilson copyright notice

### DIFF
--- a/aboutwilson/templates/base.html
+++ b/aboutwilson/templates/base.html
@@ -90,7 +90,7 @@
 <div class="container">
 	<div class="row">
 		<div class="col-md-12 text-center center-block aw-bottom">
-			<p>&copy; {{ AUTHOR }} 2014</p>
+			<p>&copy; {{ AUTHOR }} 2016</p>
 			<p>Powered by Pelican</p>
 		</div>
 	</div>


### PR DESCRIPTION
I'm new to pelican and haven't looked into how to do this dynamically with a template variable. Neither `{{ year }}` nor `{{ YEAR }}` seemed to be defined, so here's a commit making the change statically for now.