### PR TITLE
pelican-bootstrap3: Fix outdated PAGES variable to "pages"

### DIFF
--- a/pelican-bootstrap3/templates/base.html
+++ b/pelican-bootstrap3/templates/base.html
@@ -122,7 +122,7 @@
                     <li><a href="{{ link }}">{{ title }}</a></li>
                 {% endfor %}
                 {% if DISPLAY_PAGES_ON_MENU %}
-                    {% for p in PAGES %}
+                    {% for p in pages %}
                          <li{% if p == page %} class="active"{% endif %}><a href="{{ SITEURL }}/{{ p.url }}">
                              {{ p.menulabel|default(p.title) }}
                           </a></li>


### PR DESCRIPTION
jinja searching the wrong variable name (PAGES instead of pages), will fail silently. Fixing the variable name will correctly display pages in the menu for any template inheriting from base.html. 