### PR TITLE
pelican-bootstrap3: hide certain elements if empty

### DIFF
--- a/pelican-bootstrap3/templates/base.html
+++ b/pelican-bootstrap3/templates/base.html
@@ -144,7 +144,9 @@
                 </form></span>
               </li>
             {% endif %}
+            {% if ARCHIVES_SAVE_AS %}
               <li><a href="{{ SITEURL }}/{{ ARCHIVES_URL | default('archives.html') }}"><i class="fa fa-th-list"></i><span class="icon-label">Archives</span></a></li>
+            {% endif %}
             </ul>
         </div>
         <!-- /.navbar-collapse -->

--- a/pelican-bootstrap3/templates/base.html
+++ b/pelican-bootstrap3/templates/base.html
@@ -105,12 +105,14 @@
 <div class="navbar {% if BOOTSTRAP_NAVBAR_INVERSE %}navbar-inverse{% else %}navbar-default{% endif %} navbar-fixed-top" role="navigation">
 	<div class="container{% if BOOTSTRAP_FLUID %}-fluid{% endif %}">
         <div class="navbar-header">
+            {% if MENUITEMS or (PAGES and DISPLAY_PAGES_ON_MENU) or (categories and DISPLAY_CATEGORIES_ON_MENU) %}
             <button type="button" class="navbar-toggle" data-toggle="collapse" data-target=".navbar-ex1-collapse">
                 <span class="sr-only">Toggle navigation</span>
                 <span class="icon-bar"></span>
                 <span class="icon-bar"></span>
                 <span class="icon-bar"></span>
             </button>
+            {% endif %}
             <a href="{{ SITEURL }}/" class="navbar-brand">
                 {% if SITELOGO %}<img src="{{ SITEURL }}/{{ SITELOGO }}" width="{{ SITELOGO_SIZE }}"/> {% endif %}
                 {% if not HIDE_SITENAME %}{{ SITENAME }}{% endif %}

--- a/pelican-bootstrap3/templates/page.html
+++ b/pelican-bootstrap3/templates/page.html
@@ -46,7 +46,9 @@
 
 {% block content %}
     <section id="content" class="body">
+        {% if page.title %}
         <h1 class="entry-title">{{ page.title }}</h1>
+        {% endif %}
         {% import 'includes/translations.html' as translations with context %}
         {{ translations.translations_for(page) }}
         {% if PDF_PROCESSOR %}


### PR DESCRIPTION
Hi,


I am using the pelican-bootstrap3 theme as a static site, and made two small changes to suite my usage better.

1. As there is no blog on my site, there are no blog archives. The link to empty archives clutters the navigation bar and has no purpose, therefore this commit introduces an option to hide the link. The Readme file has been updated to mention the option.

2. On my static index page I don't set a page title. However, the h1 tag still exists in the HTML. This commit introduces a check for an empty title and, if empty, does not print the h1 tag.


Best,

Clemens