### PR TITLE
Use HTTPS Creative Commons URLs where appropriate

### DIFF
--- a/backdrop/templates/footer.html
+++ b/backdrop/templates/footer.html
@@ -35,7 +35,7 @@
         <div class="small-12 medium-6 columns">
             <p class="small-text-center medium-text-left">
                 &copy; {{ YEAR }} {{ AUTHOR }} {{ LICENSE }}
-                <!-- <a rel="license" href="http://creativecommons.org/licenses/by-nc-sa/4.0/"><img alt="Creative Commons License" style="border-width:0" src="cc.png" /></a>-->
+                <!-- <a rel="license" href="https://creativecommons.org/licenses/by-nc-sa/4.0/"><img alt="Creative Commons License" style="border-width:0" src="cc.png" /></a>-->
             </p>
         </div>
         <div class="small-12 medium-6 columns">

--- a/backdrop/templates/sample.html
+++ b/backdrop/templates/sample.html
@@ -89,7 +89,7 @@
             <hr>
             <div class="small-12 medium-6 columns">
                 <p class="small-text-center medium-text-left">&copy; 2015 Chris MacMackin 
-                <a rel="license" href="http://creativecommons.org/licenses/by-nc-sa/4.0/"><img alt="Creative Commons License" style="border-width:0" src="cc.png" /></a></p>
+                <a rel="license" href="https://creativecommons.org/licenses/by-nc-sa/4.0/"><img alt="Creative Commons License" style="border-width:0" src="cc.png" /></a></p>
             </div>
             <div class="small-12 medium-6 columns">
                 <p class="small-text-center medium-text-right">Proudly powered by 
@@ -176,7 +176,7 @@
             <hr>
             <div class="small-12 medium-6 columns">
                 <p class="small-text-center medium-text-left">&copy; 2015 Chris MacMackin 
-                <a rel="license" href="http://creativecommons.org/licenses/by-nc-sa/4.0/"><img alt="Creative Commons License" style="border-width:0" src="cc.png" /></a></p>
+                <a rel="license" href="https://creativecommons.org/licenses/by-nc-sa/4.0/"><img alt="Creative Commons License" style="border-width:0" src="cc.png" /></a></p>
             </div>
             <div class="small-12 medium-6 columns">
                 <p class="small-text-center medium-text-right">Proudly powered by 

--- a/martyalchin/templates/base.html
+++ b/martyalchin/templates/base.html
@@ -10,6 +10,6 @@
     {% block content %} {% endblock %}
 
     <div class="copyright info vcard">Design by <a class="fn url"
-    href="http://martyalchin.com">Marty Alchin</a>, <a rel="license" href="http://creativecommons.org/licenses/by-sa/3.0/us/">some rights reserved</a>. Powered by <a href="http://alexis.notomyidea.org/pelican/">pelican</a></div>
+    href="http://martyalchin.com">Marty Alchin</a>, <a rel="license" href="https://creativecommons.org/licenses/by-sa/3.0/us/">some rights reserved</a>. Powered by <a href="http://alexis.notomyidea.org/pelican/">pelican</a></div>
     </body>
 </html>

--- a/pelican-bootstrap3/README.md
+++ b/pelican-bootstrap3/README.md
@@ -207,7 +207,7 @@ If you're using reStructuredText for writing articles and pages, you can include
 
 ### Content license
 
-You can optionally declare a [Creative Commons license](http://creativecommons.org) for the content of your site. It will appear in the site's footer. To enable, use one of the following two ways for configuration.
+You can optionally declare a [Creative Commons license](https://creativecommons.org) for the content of your site. It will appear in the site's footer. To enable, use one of the following two ways for configuration.
 
 * To choose the license by name, set `CC_LICENSE` to the common abbreviated name of the license: `"CC-BY"` (require attribution), `"CC-BY-SA"` (require ShareAlike), `"CC-BY-ND"` (NoDerivatives) , `"CC-BY-NC"` (require attribution, no commercial reuse), `"CC-BY-NC-SA"` (require ShareAlike, no commercial reuse), or `"CC-BY-NC-ND"` (NoDerivatives, no commercial reuse).
 * Alternatively, choose the licence by features:
@@ -215,7 +215,7 @@ You can optionally declare a [Creative Commons license](http://creativecommons.o
     * `CC_LICENSE_COMMERCIAL` - `"yes"` if commercial reuse is permitted, and `"no"` otherwise.
 * Optionally, you can include attribution markup in the license mark by setting `CC_ATTR_MARKUP` to _True_.
 
-The license choice mirrors the [Creative Commons License Chooser](http://creativecommons.org/choose/). Source for the macro that renders the mark is at http://github.com/hlapp/cc-tools.
+The license choice mirrors the [Creative Commons License Chooser](https://creativecommons.org/choose/). Source for the macro that renders the mark is at http://github.com/hlapp/cc-tools.
 
 Alternatively, if you want to use another license type, you can instead use the `CUSTOM_LICENSE` property to set a license string that will be showed at the bottom of every page.
 Raw HTML is allowed.

--- a/pelican-bootstrap3/templates/includes/cc-license.html
+++ b/pelican-bootstrap3/templates/includes/cc-license.html
@@ -24,7 +24,7 @@
 {#               specifying how under which title, to which creator, and    #}
 {#               to which URL to attribute the work                         #}
 {# The parameters all mirror the Creative Commone license chooser:          #}
-{# http://creativecommons.org/choose/                                       #}
+{# https://creativecommons.org/choose/                                      #}
 {# ------------------------------------------------------------------------ #}
 {# Copyright (c) 1994 Hilmar Lapp, hlapp@drycafe.net.                       #}
 {# Licensed under the terms of the MIT License.                             #}
@@ -53,7 +53,7 @@
       {% set cc_title_suffix = cc_title_suffix ~ "-ShareAlike" %}
     {% endif %}
   {% endif %}
-  {% set cc_title, cc_uri, cc_icon = ("Creative Commons AttributionCCSUFFIX 4.0 International License","http://creativecommons.org/licenses/CCNAME/4.0/","//i.creativecommons.org/l/CCNAME/4.0/80x15.png") %}
+  {% set cc_title, cc_uri, cc_icon = ("Creative Commons AttributionCCSUFFIX 4.0 International License","https://creativecommons.org/licenses/CCNAME/4.0/","//i.creativecommons.org/l/CCNAME/4.0/80x15.png") %}
   <a rel="license" href="{{ cc_uri|replace('CCNAME',cc_name) }}"><img alt="Creative Commons License" style="border-width:0" src="{{ cc_icon|replace('CCNAME',cc_name) }}" /></a>
   {% if br_after_img %}<br/>{% endif %}
   {% if attr_markup %}

--- a/photowall/templates/base.html
+++ b/photowall/templates/base.html
@@ -74,7 +74,7 @@ function greyon(img)
         </section><!-- /#extras -->
 
         <footer id="contentinfo" class="body">
-		<a rel="license" href="http://creativecommons.org/licenses/by-nc-sa/4.0/"><img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by-nc-sa/4.0/88x31.png" /></a>
+		<a rel="license" href="https://creativecommons.org/licenses/by-nc-sa/4.0/"><img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by-nc-sa/4.0/88x31.png" /></a>
         </footer><!-- /#contentinfo -->
 
 {% include 'analytics.html' %}


### PR DESCRIPTION
This pull request changes `http://creativecommons.org/...` URLS to `https://creativecommons.org/...` in five templates and one README. It does not make this change in four font-awesome.css files, to maintain consistency with what I assume comes from Font Awesome upstream, or one xmlns attribute.

Full disclosure: the official [CC license chooser](https://creativecommons.org/choose/) produces HTTP URLs even though the HTTPS URLs I tested work.