### PR TITLE
Bootstrap3: remove deprecated Twitter widget ID

### DIFF
--- a/pelican-bootstrap3/templates/includes/twitter_timeline.html
+++ b/pelican-bootstrap3/templates/includes/twitter_timeline.html
@@ -2,9 +2,6 @@
 
     <li class="list-group-item"><h4><i class="fa fa-twitter fa-lg"></i><span class="icon-label">Latest Tweets</span></h4></li>
     <div id="twitter_timeline">
-        <a class="twitter-timeline" data-chrome="noheader" href="https://twitter.com/{{ TWITTER_USERNAME }}" data-widget-id="{{TWITTER_WIDGET_ID}}">Tweets by {{TWITTER_USERNAME}}</a>
+        <a class="twitter-timeline" data-width="250" data-height="300" data-dnt="true" data-theme="light" href="https://twitter.com/{{TWITTER_USERNAME}}">Tweets by {{TWITTER_USERNAME}}</a> <script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>
     </div>
-
-<script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],p=/^http:/.test(d.location)?'http':'https';if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src=p+"://platform.twitter.com/widgets.js";fjs.parentNode.insertBefore(js,fjs);}}(document,"script","twitter-wjs");</script>
-
 {% endif %}


### PR DESCRIPTION
Also, Widget ID appears to no longer exist anymore on Twitter's end.