### PR TITLE
Fix eevee submodule path

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -219,4 +219,4 @@
 	url = https://github.com/mothsART/pelican-lab
 [submodule "eevee"]
 	path = eevee
-	url = git@github.com:kura/eevee.git
+	url = https://github.com/kura/eevee.git


### PR DESCRIPTION
Use 'https' instead of 'git' for the submodule scheme so non-@kura
users can successfully update submodules.