### PR TITLE
aboutwilson: Correct theme category links. Fixes #426

### DIFF
--- a/aboutwilson/templates/base.html
+++ b/aboutwilson/templates/base.html
@@ -68,7 +68,7 @@
 						<h4>Categories</h4>
 						<ul class="list-unstyled my-list-style">
 							{% for cat, art in categories %}
-							<li><a href="{{SITEURL}}/category/{{cat | replace(" ", "-") }}.html">{{cat}} ({{art | count}})</a></li>
+							<li><a href="{{SITEURL}}/category/{{cat | replace(" ", "-") | lower }}.html">{{cat}} ({{art | count}})</a></li>
 							{% endfor %}
 						</ul>
 					</div>


### PR DESCRIPTION
Fixed broken links for categories. Without the fix the URLs result in a 404 status when a category link is clicked.
	modified:   aboutwilson/templates/base.html