### PR TITLE
bootlex: Add UTF-8 meta charset definition

### DIFF
--- a/bootlex/templates/base.html
+++ b/bootlex/templates/base.html
@@ -4,6 +4,7 @@
   <head>
     {% block head %}
     <title>{% block title %}{% endblock title %} - {{ SITENAME }}</title>
+    <meta charset="utf-8" />
     <link href="http://fonts.googleapis.com/css?family=Arimo:400,700|Inika" rel="stylesheet" type="text/css" />
     <link rel="stylesheet" type="text/css" href="{{ SITEURL }}/theme/bootstrap.css" />
     <link rel="stylesheet" type="text/css" href="{{ SITEURL }}/theme/pastie.css" />


### PR DESCRIPTION
Added meta tag with charset definition to <head> in base.html template of "bootlex" theme