### PR TITLE
pelican-bootstrap3: fix icon for instagram social link

### DIFF
--- a/pelican-bootstrap3/templates/includes/sidebar.html
+++ b/pelican-bootstrap3/templates/includes/sidebar.html
@@ -13,7 +13,7 @@
                     {% else %}
                         {% set name_sanitized = s[0]|lower|replace('+','-plus')|replace(' ','-') %}
                     {% endif %}
-                    {% if name_sanitized in ['flickr', 'slideshare', 'spotify', 'stack-overflow', 'weibo', 'line-chart'] %}
+                    {% if name_sanitized in ['flickr', 'instagram', 'slideshare', 'spotify', 'stack-overflow', 'weibo', 'line-chart'] %}
                         {% set iconattributes = '"fa fa-' ~ name_sanitized ~ ' fa-lg"' %}
                     {% else %}
                         {% set iconattributes = '"fa fa-' ~ name_sanitized ~ '-square fa-lg"' %}


### PR DESCRIPTION
fa-instagram-square does not exist.