### PR TITLE
Allow moving sidebar to left in pelican-bootstrap3

### DIFF
--- a/pelican-bootstrap3/README.md
+++ b/pelican-bootstrap3/README.md
@@ -237,7 +237,7 @@ icon to show. You can provide an alternative icon string as the third string (as
 * **Recent Posts** will be shown if `DISPLAY_RECENT_POSTS_ON_SIDEBAR` is set to _True_
 	* Use `RECENT_POST_COUNT` to control the amount of recent posts. Defaults to **5**
 
-To remove the sidebar entirely, set `HIDE_SIDEBAR` to _True_.
+To remove the sidebar entirely, set `HIDE_SIDEBAR` to _True_. To move the sidebar to the left, set `SIDEBAR_ON_LEFT` to _True_.
 
 ### reStructuredText styles
 

--- a/pelican-bootstrap3/templates/base.html
+++ b/pelican-bootstrap3/templates/base.html
@@ -164,7 +164,7 @@
 <div class="container{% if BOOTSTRAP_FLUID %}-fluid{% endif %}">
     <div class="row">
         {% if not HIDE_SIDEBAR or ABOUT_ME %}
-        <div class="col-sm-9">
+        <div class="col-sm-9{% if SIDEBAR_ON_LEFT %} col-sm-push-3{% endif %}">
         {% else %}
         <div class="col-lg-12">
         {% endif %}
@@ -174,7 +174,7 @@
         {% endblock %}
         </div>
         {% if not HIDE_SIDEBAR or ABOUT_ME %}
-        <div class="col-sm-3" id="sidebar">
+        <div class="col-sm-3{% if SIDEBAR_ON_LEFT %} col-sm-pull-9{% endif %}" id="sidebar">
             <aside>
             {% if ABOUT_ME %}
                 {% include 'includes/aboutme.html' %}


### PR DESCRIPTION
Added the `SIDEBAR_ON_LEFT` configuration option, which moves the
sidebar to the left side of the page.

Sidebar will continue to appear on the bottom of the page on smaller
screens.