### PR TITLE
Make icons in sidebar titles optional in pelican-bootstrap3

### DIFF
--- a/pelican-bootstrap3/README.md
+++ b/pelican-bootstrap3/README.md
@@ -237,7 +237,11 @@ icon to show. You can provide an alternative icon string as the third string (as
 * **Recent Posts** will be shown if `DISPLAY_RECENT_POSTS_ON_SIDEBAR` is set to _True_
 	* Use `RECENT_POST_COUNT` to control the amount of recent posts. Defaults to **5**
 
-To remove the sidebar entirely, set `HIDE_SIDEBAR` to _True_.
+Other sidebar related options include:
+
+* To remove the sidebar entirely, set `HIDE_SIDEBAR` to _True_.
+* To turn off inlined icons in the titles set `DISABLE_SIDEBAR_TITLE_ICONS` to
+  _True_.
 
 ### reStructuredText styles
 

--- a/pelican-bootstrap3/templates/includes/github.html
+++ b/pelican-bootstrap3/templates/includes/github.html
@@ -1,6 +1,8 @@
 {% if GITHUB_USER %}
 
-    <li class="list-group-item"><h4><i class="fa fa-github fa-lg"></i><span class="icon-label">GitHub Repos</span></h4>
+    {% from 'includes/sidebar_title.html' import title %}
+    <li class="list-group-item">
+        <h4>{{ title('GitHub Repos', DISABLE_SIDEBAR_TITLE_ICONS, icon='github') }}</h4>
         <div id="gh_repos">
             <p class="list-group-item">Status updating...</p>
         </div>

--- a/pelican-bootstrap3/templates/includes/links.html
+++ b/pelican-bootstrap3/templates/includes/links.html
@@ -1,5 +1,8 @@
 {% if LINKS %}
-    <li class="list-group-item"><h4><i class="fa fa-external-link-square fa-lg"></i><span class="icon-label">Links</span></h4>
+
+    {% from 'includes/sidebar_title.html' import title %}
+    <li class="list-group-item">
+      <h4>{{ title('Links', DISABLE_SIDEBAR_TITLE_ICONS, icon='external-link-square') }}</h4>
       <ul class="list-group" id="links">
         {% for name, link in LINKS %}
         <li class="list-group-item">

--- a/pelican-bootstrap3/templates/includes/sidebar-images.html
+++ b/pelican-bootstrap3/templates/includes/sidebar-images.html
@@ -1,8 +1,10 @@
 {% if SIDEBAR_IMAGES %}
-    {% if SIDEBAR_IMAGES_HEADER %}
-        <li class="list-group-item"><h4><i class="fa fa-external-link-square fa-lg"></i><span class="icon-label">{{ SIDEBAR_IMAGES_HEADER }}</span></h4>
-    {% endif %}
+
+    {% from 'includes/sidebar_title.html' import title %}
     <li class="list-group-item">
+        {% if SIDEBAR_IMAGES_HEADER %}
+        <h4>{{ title(SIDEBAR_IMAGES_HEADER, DISABLE_SIDEBAR_TITLE_ICONS, icon='external-link-square') }}</h4>
+        {% endif %}
         <ul class="list-group" id="links">
         {% for image in SIDEBAR_IMAGES %}
             <img width="100%" class="img-thumbnail" src="{{ image }}"/>

--- a/pelican-bootstrap3/templates/includes/sidebar.html
+++ b/pelican-bootstrap3/templates/includes/sidebar.html
@@ -1,3 +1,5 @@
+{% from 'includes/sidebar_title.html' import title %}
+
 {% if DISPLAY_TAGS_ON_SIDEBAR is not defined %}
     {% set DISPLAY_TAGS_ON_SIDEBAR = True %}
 {% endif %}
@@ -5,7 +7,8 @@
 <section class="well well-sm">
     <ul class="list-group list-group-flush">
         {% if SOCIAL %}
-            <li class="list-group-item"><h4><i class="fa fa-home fa-lg"></i><span class="icon-label">Social</span></h4>
+            <li class="list-group-item">
+              <h4>{{ title('Social', DISABLE_SIDEBAR_TITLE_ICONS) }}</h4>
               <ul class="list-group" id="social">
                 {% for s in SOCIAL %}
                     {% if s[2] %}
@@ -28,7 +31,8 @@
             {% if RECENT_POST_COUNT is not defined %}
                 {% set RECENT_POST_COUNT = 5 %}
             {% endif %}
-            <li class="list-group-item"><h4><i class="fa fa-home fa-lg"></i><span class="icon-label">Recent Posts</span></h4>
+            <li class="list-group-item">
+                <h4>{{ title('Recent Posts', DISABLE_SIDEBAR_TITLE_ICONS) }}</h4>
                 <ul class="list-group" id="recentposts">
                 {% for article in articles[:RECENT_POST_COUNT] %}
                     <li class="list-group-item">
@@ -42,12 +46,16 @@
         {% endif %}
 
         {% if DISPLAY_CATEGORIES_ON_SIDEBAR %}
-            <li class="list-group-item"><a href="{{ SITEURL }}/{{ CATEGORIES_URL }}"><h4><i class="fa fa-home fa-lg"></i><span class="icon-label">Categories</span></h4></a>
+            <li class="list-group-item">
+                <h4>{{ title('Categories', DISABLE_SIDEBAR_TITLE_ICONS) }}</h4>
                 <ul class="list-group" id="categories">
                 {% for cat, null in categories %}
                     <li class="list-group-item">
                         <a href="{{ SITEURL }}/{{ cat.url }}">
-                            <i class="fa fa-folder-open fa-lg"></i> {{ cat }}
+                            {%- if not DISABLE_SIDEBAR_TITLE_ICONS -%}
+                            <i class="fa fa-folder-open fa-lg"></i>
+                            {%- endif -%}
+                            {{- cat -}}
                         </a>
                     </li>
                 {% endfor %}
@@ -61,7 +69,8 @@
             {% else %}
                 {% set tags = tag_cloud | sort(attribute='1') %}
             {% endif %}
-            <li class="list-group-item"><a href="{{ SITEURL }}/{{ TAGS_URL }}"><h4><i class="fa fa-tags fa-lg"></i><span class="icon-label">Tags</span></h4></a>
+            <li class="list-group-item">
+                <a href="{{ SITEURL }}/{{ TAGS_URL }}"><h4>{{ title('Tags', DISABLE_SIDEBAR_TITLE_ICONS, icon='tags') }}</h4></a>
                 <ul class="list-group {% if DISPLAY_TAGS_INLINE %}list-inline tagcloud{% endif %}" id="tags">
                 {% for tag in tags %}
                     <li class="list-group-item tag-{{ tag.1 }}">
@@ -77,7 +86,8 @@
         {% if DISPLAY_SERIES_ON_SIDEBAR %}
             {% if article %}
                 {% if article.series %}
-                    <li class="list-group-item"><h4><i class="fa fa-tags fa-list-ul"></i><span class="icon-label">Series</span></h4>
+                    <li class="list-group-item">
+                        <h4>{{ title('Series', DISABLE_SIDEBAR_TITLE_ICONS, icon='tags') }}</h4>
                         <ul class="list-group">
                             <li class="list-group-item">
                             {% if article.series.previous %}

--- a/pelican-bootstrap3/templates/includes/sidebar_title.html
+++ b/pelican-bootstrap3/templates/includes/sidebar_title.html
@@ -1,0 +1,7 @@
+{% macro title(name, no_icon, icon='home') -%}
+    {%- if no_icon -%}
+        {{ name }}
+    {%- else -%}
+        <i class="fa fa-{{ icon }} fa-lg"></i><span class="icon-label">{{ name }}</span>
+    {%- endif -%}
+{%- endmacro %}

--- a/pelican-bootstrap3/templates/includes/twitter_timeline.html
+++ b/pelican-bootstrap3/templates/includes/twitter_timeline.html
@@ -1,7 +1,10 @@
 {% if TWITTER_WIDGET_ID %}
 
-    <li class="list-group-item"><h4><i class="fa fa-twitter fa-lg"></i><span class="icon-label">Latest Tweets</span></h4></li>
-    <div id="twitter_timeline">
-        <a class="twitter-timeline" data-width="250" data-height="300" data-dnt="true" data-theme="light" href="https://twitter.com/{{TWITTER_USERNAME}}">Tweets by {{TWITTER_USERNAME}}</a> <script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>
-    </div>
+    {% from 'includes/sidebar_title.html' import title %}
+    <li class="list-group-item">
+      <h4>{{ title('Latest Tweets', DISABLE_SIDEBAR_TITLE_ICONS, icon='twitter') }}</h4>
+      <div id="twitter_timeline">
+          <a class="twitter-timeline" data-width="250" data-height="300" data-dnt="true" data-theme="light" href="https://twitter.com/{{TWITTER_USERNAME}}">Tweets by {{TWITTER_USERNAME}}</a> <script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>
+      </div>
+    </li>
 {% endif %}


### PR DESCRIPTION
Added the `DISABLE_SIDEBAR_TITLE_ICONS` configuration option.  If
`DISABLE_SIDEBAR_TITLE_ICONS` is set to `True`, none of the sidebar
title icons will be displayed.