### PR TITLE
Move if tags to hide empty li tags at the beginning or end of a series

### DIFF
--- a/pelican-bootstrap3/templates/includes/sidebar.html
+++ b/pelican-bootstrap3/templates/includes/sidebar.html
@@ -79,18 +79,18 @@
                 {% if article.series %}
                     <li class="list-group-item"><h4><i class="fa fa-tags fa-list-ul"></i><span class="icon-label">Series</span></h4>
                         <ul class="list-group">
-                            <li class="list-group-item">
                             {% if article.series.previous %}
+                            <li class="list-group-item">
                                 <h5></i> Previous article</h5>
                                 <a href="{{ SITEURL }}/{{ article.series.previous.url }}">{{ article.series.previous.title }}</a>
-                            {% endif %}
                             </li>
-                            <li class="list-group-item">
+                            {% endif %}
                             {% if article.series.next %}
+                            <li class="list-group-item">
                                 <h5>Next article</h5>
                                 <a href="{{ SITEURL }}/{{ article.series.next.url }}">{{ article.series.next.title }}</a>
-                            {% endif %}
                             </li>
+                            {% endif %}
                         </ul>
                     </li>
                 {% endif%}


### PR DESCRIPTION
This change hides empty ``li`` tags when at the beginning or end of a series. If they are not hidden, they render odd looking space above or below links.