### PR TITLE
pelican-bootstrap3: Hide empty <li> tags when at either end of a series

### DIFF
--- a/pelican-bootstrap3/templates/includes/sidebar.html
+++ b/pelican-bootstrap3/templates/includes/sidebar.html
@@ -79,18 +79,18 @@
                 {% if article.series %}
                     <li class="list-group-item"><h4><i class="fa fa-tags fa-list-ul"></i><span class="icon-label">Series</span></h4>
                         <ul class="list-group">
-                            <li class="list-group-item">
                             {% if article.series.previous %}
+                            <li class="list-group-item">
                                 <h5></i> Previous article</h5>
                                 <a href="{{ SITEURL }}/{{ article.series.previous.url }}">{{ article.series.previous.title }}</a>
-                            {% endif %}
                             </li>
-                            <li class="list-group-item">
+                            {% endif %}
                             {% if article.series.next %}
+                            <li class="list-group-item">
                                 <h5>Next article</h5>
                                 <a href="{{ SITEURL }}/{{ article.series.next.url }}">{{ article.series.next.title }}</a>
-                            {% endif %}
                             </li>
+                            {% endif %}
                         </ul>
                     </li>
                 {% endif%}
@@ -103,4 +103,3 @@
         {% include 'includes/sidebar-images.html' %}
     </ul>
 </section>
-


### PR DESCRIPTION
This hides empty ``li`` tags when you are at either end of an article series. At the moment the empty ``li`` tags are displayed giving some awkward spacing in the sidebar.