### PR TITLE
Fix avatar source URL for subpages in pelican-bootstrap3

### DIFF
--- a/pelican-bootstrap3/templates/includes/aboutme.html
+++ b/pelican-bootstrap3/templates/includes/aboutme.html
@@ -1,7 +1,7 @@
 <div id="aboutme">
     {% if AVATAR %}
         <p>
-            <img width="100%" class="img-thumbnail" src="{{ AVATAR }}"/>
+            <img width="100%" class="img-thumbnail" src="{{ SITEURL }}/{{ AVATAR }}"/>
         </p>
     {% endif %}
     <p>


### PR DESCRIPTION
When going to a subpage, such as a category page, my avatar image was not
being displayed when using the suggested format 'images/profile.png' from
the readme. The URL turned into 'category/images/profile.png' which doesn't
exist.

Include the site URL so that the image appears on all pages. This looked
like the convention used in other places like favicon.