### PR TITLE
Fix bootstrap2 atom feed in sidebar

### DIFF
--- a/bootstrap2/templates/sidebar.html
+++ b/bootstrap2/templates/sidebar.html
@@ -7,7 +7,9 @@
 {% endif %}
 {% if SOCIAL %}
 <li class="nav-header"><h4><i class="icon-home icon-large"></i> social</h4></li>
-<li><a href="{{ SITEURL }}/{{ FEED }}" rel="alternate"><i class="icon-bookmark icon-large"></i>atom feed</a></li>
+{% if FEED_ALL_ATOM %}
+<li><a href="{{ SITEURL }}/{{ FEED_ALL_ATOM }}" rel="alternate"><i class="icon-bookmark icon-large"></i>atom feed</a></li>
+{% endif %}
 {% if FEED_RSS %}
 <li><a href="{{ SITEURL }}/{{ FEED_RSS }}" rel="alternate"><i class="icon-bookmark icon-large"></i>rss feed</a></li>
 {% endif %}


### PR DESCRIPTION
Presently, the bootstrap2 sidebar breaks atom feeds, as it doesn't check that the FEED_ALL_ATOM variable is set (in fact, it actually looks for the wrong variable from before the feed refactor).