### PR TITLE
pelican-bootstrap3: Add icons to "social" sidebar

### DIFF
--- a/pelican-bootstrap3/templates/includes/sidebar.html
+++ b/pelican-bootstrap3/templates/includes/sidebar.html
@@ -13,7 +13,7 @@
                     {% else %}
                         {% set name_sanitized = s[0]|lower|replace('+','-plus')|replace(' ','-') %}
                     {% endif %}
-                    {% if name_sanitized in ['flickr', 'slideshare', 'spotify', 'stack-overflow', 'weibo', 'line-chart'] %}
+                    {% if name_sanitized in ['flickr', 'slideshare', 'spotify', 'stack-overflow', 'weibo', 'line-chart', 'home', 'user', 'users', 'envelope', 'envelope-o', 'stack-exchange', 'hacker-news'] %}
                         {% set iconattributes = '"fa fa-' ~ name_sanitized ~ ' fa-lg"' %}
                     {% else %}
                         {% set iconattributes = '"fa fa-' ~ name_sanitized ~ '-square fa-lg"' %}


### PR DESCRIPTION
The template adds "-square" to the Font Awesome icon to be used,
unless the icon name is on the exception list. Some icon names
potentially relevant for the "social" sidebar block do not have
a "-square" version but are not on the exception list, so the
icons do not display correctly.

Add more relevant icon names to the list: 'home', 'user', 'users',
'envelope', 'envelope-o', 'stack-exchange', 'hacker-news'.