### PR TITLE
pelican-bootstrap3: Fix display of "About Me"

### DIFF
--- a/pelican-bootstrap3/templates/base.html
+++ b/pelican-bootstrap3/templates/base.html
@@ -168,7 +168,7 @@
 <!-- End Banner -->
 <div class="container{% if BOOTSTRAP_FLUID %}-fluid{% endif %}">
     <div class="row">
-        {% if not HIDE_SIDEBAR or ABOUT_ME %}
+        {% if not HIDE_SIDEBAR or ABOUT_ME or AVATAR %}
         <div class="col-sm-9">
         {% else %}
         <div class="col-lg-12">
@@ -178,10 +178,10 @@
         {% block content %}
         {% endblock %}
         </div>
-        {% if not HIDE_SIDEBAR or ABOUT_ME %}
+        {% if not HIDE_SIDEBAR or ABOUT_ME or AVATAR %}
         <div class="col-sm-3" id="sidebar">
             <aside>
-            {% if ABOUT_ME %}
+            {% if ABOUT_ME or AVATAR %}
                 {% include 'includes/aboutme.html' %}
             {% endif %}
             {% if not HIDE_SIDEBAR %}

--- a/pelican-bootstrap3/templates/includes/aboutme.html
+++ b/pelican-bootstrap3/templates/includes/aboutme.html
@@ -4,8 +4,10 @@
             <img width="100%" class="img-thumbnail" src="{{ AVATAR }}"/>
         </p>
     {% endif %}
+    {% if ABOUT_ME %}
     <p>
         <strong>About {{ AUTHOR }}</strong><br/>
         {{ ABOUT_ME }}
     </p>
+    {% endif %}
 </div>


### PR DESCRIPTION
The "About Me" block (defined in templates/includes/aboutme.html)
consists of the image defined by AVATAR and the text in ABOUT_ME.
However, the template only displays the block if ABOUT_ME is defined.
If only AVATAR is defined, then the block is not displayed at all.

- Change the test so the "About Me" block is displayed if either
ABOUT_ME or AVATAR is defined.

- Change the structure of the "About Me" block so that the heading for
the ABOUT_ME text is displayed only if ABOUT_ME text is defined,
to avoid an empty heading. If AVATAR is defined but ABOUT_ME is not,
the block displays the AVATAR image only.