### PR TITLE
pelican-bootstrap3: extended sidebar images to include images with attributes.

### DIFF
--- a/pelican-bootstrap3/templates/includes/sidebar-images.html
+++ b/pelican-bootstrap3/templates/includes/sidebar-images.html
@@ -1,4 +1,4 @@
-{% if SIDEBAR_IMAGES %}
+{% if SIDEBAR_IMAGES or SIDEBAR_IMAGES_WITH_ATTRIBUTES %}
     {% if SIDEBAR_IMAGES_HEADER %}
         <li class="list-group-item"><h4><i class="fa fa-external-link-square fa-lg"></i><span class="icon-label">{{ SIDEBAR_IMAGES_HEADER }}</span></h4>
     {% endif %}
@@ -6,6 +6,9 @@
         <ul class="list-group" id="links">
         {% for image in SIDEBAR_IMAGES %}
             <img width="100%" class="img-thumbnail" src="{{ image }}"/>
+        {% endfor %}
+        {% for name, attributes in SIDEBAR_IMAGES_WITH_ATTRIBUTES.iteritems() %}
+            {% if attributes.href is defined %}<a href="{{ attributes.href }}">{% endif %}<img width="{% if attributes.width is defined %}{{ attributes.width }}{% else %}100%{% endif %}" class="{% if attributes.class is defined %}{{ attributes.class }}{% else %}img-thumbnail{% endif %}" src="{{ attributes.src }}"/>{% if attributes.href is defined %}</a>{% endif %}
         {% endfor %}
         </ul>
     </li>


### PR DESCRIPTION
Add images with attributes to the sidebar. In pelicanconf.py add a
SIDEBAR_IMAGES_WITH_ATTRIBUTES dictionary:

    SIDEBAR_IMAGES_WITH_ATTRIBUTES = {
        'image-with-link': {
            'href': 'http://example.org',
            'src': 'images/example.jpg',
            'width': '90%',
            'class': 'img-rounded'
        }
    }

Which should render:

    <a href="http://example.org"><img width="90%" class="img-rounded" src="images/example.jpg"/></a>