### PR TITLE
tuxlite_tbs: change PAGES context variable to pages

### DIFF
--- a/tuxlite_tbs/templates/base.html
+++ b/tuxlite_tbs/templates/base.html
@@ -55,7 +55,7 @@
         {% endfor %}
             
         {% if DISPLAY_PAGES_ON_MENU %}
-        {% for page in PAGES %}
+        {% for page in pages %}
             <li><a href="{{ SITEURL }}/{{ page.url }}">{{ page.title }}</a></li>
         {% endfor %}
         {% endif %}


### PR DESCRIPTION
Saw the issue [here](https://github.com/getpelican/pelican-themes/issues/437) when I was trying to figure out why pages were not showing up for me when I upgraded pelican.  