### PR TITLE
Fix Python 3 unorderable types issue with multiple themes

### DIFF
--- a/SOB/templates/tags.html
+++ b/SOB/templates/tags.html
@@ -6,7 +6,7 @@
 			<li><a href="{{ SITEURL }}/{{ tag.url }}">{{ tag }}</a></li>
 			<ul class="square">
 
-			{% for article in articles|sort %}
+			{% for article in articles %}
 				<li><a href="{{ SITEURL }}/{{ article.url }}"><small>{{ article.title }}</small></li>
 			{% endfor %}
 			</ul>

--- a/ops/templates/category.html
+++ b/ops/templates/category.html
@@ -9,7 +9,7 @@
         </header>
         <dl>
             <h3>{{ category }}</h3>
-            {% for article in articles|sort %}
+            {% for article in articles %}
                 <dd>
                     <a href="{{ SITEURL }}/{{ article.url }}">{{ article.title }}</a>
                 </dd>

--- a/ops/templates/tag.html
+++ b/ops/templates/tag.html
@@ -9,7 +9,7 @@
         </header>
         <dl>
             <h3>{{ tag }}</h3>
-            {% for article in articles|sort %}
+            {% for article in articles %}
 
                 <dd>
                     <a href="{{ SITEURL }}/{{ article.url }}">{{ article.title }}</a>

--- a/ops/templates/tags.html
+++ b/ops/templates/tags.html
@@ -5,7 +5,7 @@
 
     <section id="tags">
         <header class="header">
-            {% for tag,articles in tags|sort %}
+            {% for tag,articles in tags %}
                 <a href="{{ SITEURL }}/{{ tag.url }}">{{ tag }}</a>({{ articles|count }})
             {% endfor %}
         </header>

--- a/tuxlite_zf/templates/tags.html
+++ b/tuxlite_zf/templates/tags.html
@@ -5,7 +5,7 @@
     {% for tag, articles in tags|sort %}
 	<li><a href="{{ SITEURL }}/{{ tag.url }}">{{ tag }}</a></li>
 	<ul class="square">
-	{% for article in articles|sort %}
+	{% for article in articles %}
 	<li><a href="{{ SITEURL }}/{{ article.url }}"><small>{{ article.title }}</small></li>
 	{% endfor %}
 	</ul>

--- a/zurb-F5-basic/templates/tags.html
+++ b/zurb-F5-basic/templates/tags.html
@@ -5,7 +5,7 @@
     {% for tag, articles in tags|sort %}
 	<li><a href="{{ SITEURL }}/{{ tag.url }}">{{ tag }}</a></li>
 	<ul class="square">
-	{% for article in articles|sort %}
+	{% for article in articles %}
 	<li><a href="{{ SITEURL }}/{{ article.url }}"><small>{{ article.title }}</small></li>
 	{% endfor %}
 	</ul>


### PR DESCRIPTION
This is to resolve #483

`{% for article in articles | sort %}` resulted in an error in Python 3: 

`"CRITICAL: unorderable types: Article() < Article()"`

I tested with Pelican 3.7.1 in both Python 2.7 & 3.5.