### PR TITLE
pelican-bootstrap3: Add PADDED_SINGLE_COLUMN_STYLE setting

### DIFF
--- a/pelican-bootstrap3/EXAMPLES.md
+++ b/pelican-bootstrap3/EXAMPLES.md
@@ -56,3 +56,5 @@ If your website is listed here, but you don't want it to be, let me know and I'l
 [Podsnap](http://blog.podsnap.com/)
 
 [The Digital Cat](http://lgiordani.com/) by [lgiordani](https://github.com/lgiordani)
+
+[droun.in](https://droun.in/) by [Pedro H.](https://github.com/digitalrounin) - Uses the `PADDED_SINGLE_COLUMN_STYLE` setting with a modified [Bootstrap/Bootswatch configuration](https://github.com/digitalrounin/bootswatch/tree/drounin/drounin) and [custom CSS](https://droun.in/css/custom.css).

--- a/pelican-bootstrap3/README.md
+++ b/pelican-bootstrap3/README.md
@@ -272,6 +272,15 @@ Other sidebar related options include:
 * To remove the sidebar entirely, set `HIDE_SIDEBAR` to _True_.
 * To move the sidebar to the left, set `SIDEBAR_ON_LEFT` to _True_.
 * To turn off inlined icons in the titles set `DISABLE_SIDEBAR_TITLE_ICONS` to
+  _True_.
+
+### Padded, Single Column Content Style
+
+The main body of the pages will be generated centered and with padding on the sides when `PADDED_SINGLE_COLUMN_STYLE` is set to `True`.
+
+The values in `HIDE_SIDEBAR`, `ABOUT_ME`, and ` AVATAR` are ignored when `PADDED_SINGLE_COLUMN_STYLE` is set to `True`.  This means that none of the sidebar content will be rendered.
+
+Use of the `PADDED_SINGLE_COLUMN_STYLE` can be seen at [droun.in](https://droun.in/).  Note that the example blog is utilizing a modified [Bootstrap/Bootswatch configuration](https://github.com/digitalrounin/bootswatch/tree/drounin/drounin) with [custom CSS](https://droun.in/css/custom.css).
 
 ### reStructuredText styles
 

--- a/pelican-bootstrap3/templates/base.html
+++ b/pelican-bootstrap3/templates/base.html
@@ -108,7 +108,7 @@
 <body>
 
 <div class="navbar {% if BOOTSTRAP_NAVBAR_INVERSE %}navbar-inverse{% else %}navbar-default{% endif %} navbar-fixed-top" role="navigation">
-	<div class="container{% if BOOTSTRAP_FLUID %}-fluid{% endif %}">
+    <div class="container{% if BOOTSTRAP_FLUID %}-fluid{% endif %}">
         <div class="navbar-header">
             {% if MENUITEMS or (pages and DISPLAY_PAGES_ON_MENU) or (categories and DISPLAY_CATEGORIES_ON_MENU) %}
             <button type="button" class="navbar-toggle" data-toggle="collapse" data-target=".navbar-ex1-collapse">
@@ -164,6 +164,7 @@
         <!-- /.navbar-collapse -->
     </div>
 </div> <!-- /.navbar -->
+
 <!-- Banner -->
 {% if BANNER and BANNER_ALL_PAGES %}
     {% include 'includes/banner.html' %}
@@ -171,32 +172,38 @@
     {% block banner %}{% endblock %}
 {% endif %}
 <!-- End Banner -->
+
+<!-- Content Container -->
+{% if PADDED_SINGLE_COLUMN_STYLE %}
+    {% set content_class='col-md-8 col-md-offset-2' %}
+{% elif not HIDE_SIDEBAR or ABOUT_ME or AVATAR %}
+    {% set content_class='col-sm-9' + (' col-sm-push-3' if SIDEBAR_ON_LEFT else '') %}
+    {% set sidebar_class='col-sm-3' + (' col-sm-pull-9' if SIDEBAR_ON_LEFT else '') %}
+{% else %}
+    {% set content_class='col-lg-12' %}
+{% endif %}
 <div class="container{% if BOOTSTRAP_FLUID %}-fluid{% endif %}">
     <div class="row">
-        {% if not HIDE_SIDEBAR or ABOUT_ME or AVATAR %}
-        <div class="col-sm-9{% if SIDEBAR_ON_LEFT %} col-sm-push-3{% endif %}">
-        {% else %}
-        <div class="col-lg-12">
-        {% endif %}
-        {% block breadcrumbs %}
-        {% endblock %}
-        {% block content %}
-        {% endblock %}
+        <div class="{{ content_class }}">
+            {% block breadcrumbs %}{% endblock %}
+            {% block content %}{% endblock %}
         </div>
-        {% if not HIDE_SIDEBAR or ABOUT_ME or AVATAR %}
-        <div class="col-sm-3{% if SIDEBAR_ON_LEFT %} col-sm-pull-9{% endif %}" id="sidebar">
+        {% if sidebar_class %}
+        <div class="{{ sidebar_class }}" id="sidebar">
             <aside>
-            {% if ABOUT_ME or AVATAR %}
-                {% include 'includes/aboutme.html' %}
-            {% endif %}
-            {% if not HIDE_SIDEBAR %}
-                {% include 'includes/sidebar.html' %}
-            {% endif %}
+                {% if ABOUT_ME or AVATAR %}
+                    {% include 'includes/aboutme.html' %}
+                {% endif %}
+                {% if not HIDE_SIDEBAR %}
+                    {% include 'includes/sidebar.html' %}
+                {% endif %}
             </aside>
         </div>
         {% endif %}
     </div>
 </div>
+<!-- End Content Container -->
+
 {% include 'includes/footer.html' %}
 
 <script src="{{ SITEURL }}/{{ THEME_STATIC_DIR }}/js/jquery.min.js"></script>


### PR DESCRIPTION
The `PADDED_SINGLE_COLUMN_STYLE` allows the main page content to be
centered with padding on the sides.

This setting takes precidence over `HIDE_SIDEBAR`, `ABOUT_ME`, and
`AVATAR`, hiding the sidebar completely when `PADDED_SINGLE_COLUMN_STYLE`
is set to `True`.

Also cleaned up how the `class`es are assigned in the main content div.
Things were starting to get unreadable in there IMHO.