### PR TITLE
Pelican-Bootstrap3: Add GitLab to non-square icon list

### DIFF
--- a/pelican-bootstrap3/templates/includes/sidebar/social.html
+++ b/pelican-bootstrap3/templates/includes/sidebar/social.html
@@ -11,7 +11,7 @@
       {% else %}
         {% set name_sanitized = s[0]|lower|replace('+','-plus')|replace(' ','-') %}
       {% endif %}
-      {% if name_sanitized in ['flickr', 'slideshare', 'instagram', 'spotify', 'stack-overflow', 'weibo', 'line-chart', 'home', 'user', 'users', 'envelope', 'envelope-o', 'stack-exchange', 'hacker-news'] %}
+      {% if name_sanitized in ['flickr', 'slideshare', 'instagram', 'spotify', 'stack-overflow', 'weibo', 'line-chart', 'home', 'user', 'users', 'envelope', 'envelope-o', 'stack-exchange', 'hacker-news', 'gitlab'] %}
         {% set iconattributes = '"fa fa-' ~ name_sanitized ~ ' fa-lg"' %}
       {% else %}
         {% set iconattributes = '"fa fa-' ~ name_sanitized ~ '-square fa-lg"' %}


### PR DESCRIPTION
This commit adds gitlab to the list of non-square icons in pelican-bootstrap3.