### PR TITLE
Fix copyright year to 2014

### DIFF
--- a/pelican-bootstrap3/templates/includes/cc-license.html
+++ b/pelican-bootstrap3/templates/includes/cc-license.html
@@ -26,7 +26,7 @@
 {# The parameters all mirror the Creative Commone license chooser:          #}
 {# https://creativecommons.org/choose/                                      #}
 {# ------------------------------------------------------------------------ #}
-{# Copyright (c) 1994 Hilmar Lapp, hlapp@drycafe.net.                       #}
+{# Copyright (c) 2014 Hilmar Lapp, hlapp@drycafe.net.                       #}
 {# Licensed under the terms of the MIT License.                             #}
 {# Source at http://github.com/hlapp/cc-tools. Please fork & contribute.    #}
 {# ------------------------------------------------------------------------ #}


### PR DESCRIPTION
See hlapp/cc-tools#3 for the corresponding change in the original source repo.

I recognize this is a minuscule change, but the year 1994 is simply wrong, makes no sense, and is simply an honest mistake.