### PR TITLE
Just-Read: Correct FEED_ATOM variable name

### DIFF
--- a/Just-Read/templates/base.html
+++ b/Just-Read/templates/base.html
@@ -18,8 +18,9 @@
 	
 	{% block scripts %}
 	{% endblock %}
-	
-	<link href="{{ SITEURL }}/{{ FEED }}" type="application/atom+xml" rel="alternate" title="{{ SITENAME }} ATOM Feed" />
+	{% if FEED_ATOM %}
+	<link href="{{ SITEURL }}/{{ FEED_ATOM }}" type="application/atom+xml" rel="alternate" title="{{ SITENAME }} ATOM Feed" />
+	{% endif %}
 	{% if FEED_RSS %}
 	<link href="{{ SITEURL }}/{{ FEED_RSS }}" type="application/atom+xml" rel="alternate" title="{{ SITENAME }} RSS Feed" />
 	{% endif %}


### PR DESCRIPTION
The pelicanconf.py variable for the ATOM feed is [FEED_ATOM](http://docs.getpelican.com/en/stable/settings.html#feed-settings), not FEED.