### PR TITLE
pelican-bootstrap3: Add DNT meta so Twitter doesn't track us

### DIFF
--- a/pelican-bootstrap3/templates/includes/twitter_cards.html
+++ b/pelican-bootstrap3/templates/includes/twitter_cards.html
@@ -1,6 +1,7 @@
 {% if TWITTER_CARDS and USE_OPEN_GRAPH %}
     {# Do not include duplicates tag with og ones. #}
     {# Twitter is able to infer them from og. #}
+    <meta name="twitter:dnt" content="on">
     <meta name="twitter:card" content="summary">
     {% if TWITTER_USERNAME %}
         <meta name="twitter:site" content="@{{ TWITTER_USERNAME }}">


### PR DESCRIPTION
As explained on this page, this meta tag prevents Twitter from using your webpage to track people:

https://dev.twitter.com/web/overview/privacy#what-privacy-options-do-website-publishers-have

Generally speaking, this is  the kind of tracking that nobody expects. Nobody thinks that by going to *my* website, which shows some tweets, that Twitter will be tracking them.

Let's turn that off by default. Hopefully this isn't controversial.