### PR TITLE
Show source support added in pelican-bootstrap3

### DIFF
--- a/pelican-bootstrap3/showsource.html
+++ b/pelican-bootstrap3/showsource.html
@@ -1,0 +1,10 @@
+{% if SHOW_SOURCE_IN_SECTION %}
+    {% if article and article.show_source_url %}
+    <section class="well" id="show-source">
+        <h4>This Page</h4>
+        <ul>
+            <a href="{{ SITEURL }}/{{ article.show_source_url }}">Show source</a>
+        </ul>
+    </section>
+    {% endif %}
+{% endif %}

--- a/pelican-bootstrap3/templates/includes/sidebar.html
+++ b/pelican-bootstrap3/templates/includes/sidebar.html
@@ -6,6 +6,7 @@
     {% include 'includes/sidebar/recent_posts.html' %}
     {% include 'includes/sidebar/categories.html' %}
     {% include 'includes/sidebar/tag_cloud.html' %}
+    {% include 'includes/sidebar/show_source.html' %}
     {% include 'includes/sidebar/series.html' %}
     {% include 'includes/sidebar/github.html' %}
     {% include 'includes/sidebar/twitter_timeline.html' %}

--- a/pelican-bootstrap3/templates/includes/sidebar/show_source.html
+++ b/pelican-bootstrap3/templates/includes/sidebar/show_source.html
@@ -1,0 +1,19 @@
+{% if SHOW_SOURCE_ON_SIDEBAR %}
+  {% if (article and article.show_source_url) or (page and page.show_source_url) %}
+
+<!-- Show source -->
+<li class="list-group-item"><h4><i class="fa fa-tags fa-file-text"></i><span class="icon-label">This Page</span></h4>
+  <ul class="list-group">
+    <li class="list-group-item">
+      {% if article %}
+      <a href="{{ SITEURL }}/{{ article.show_source_url }}">Show source</a>
+      {% elif page %}
+      <a href="{{ SITEURL }}/{{ page.show_source_url }}">Show source</a>
+      {% endif %}
+    </li>
+  </ul>
+</li>
+<!-- End Show source -->
+
+  {% endif %}
+{% endif %}


### PR DESCRIPTION
Update to pelican-boostrap3 to support the [Show Source](https://github.com/getpelican/pelican-plugins/tree/master/show_source) plugin.