### PR TITLE
Fix the last pagination block jumps to a new line

### DIFF
--- a/pelican-bootstrap3/templates/includes/pagination.html
+++ b/pelican-bootstrap3/templates/includes/pagination.html
@@ -22,7 +22,7 @@
             {% else %}
                 <li class="prev disabled"><a href="#">&laquo;</a></li>
             {% endif %}
-            {% for num in range( 1, 1 + articles_paginator.num_pages ) %}
+            {% for num in range( 1, articles_paginator.num_pages ) %}
                     <li class="{{ 'active' if num == articles_page.number else '' }}"><a
                             href="{{ SITEURL }}/{{ articles_paginator.page(num).url if num > 1 else articles_paginator.page(1).url }}">{{ num }}</a></li>
                 {% endfor %}


### PR DESCRIPTION
On moderately small laptop screen (1366x768) the one last pagination block has jump to newline.

How it looks now:
```
[<<] [1] [2] .... [21]
[>>]   <<--- here last block on the newline :(
```

How it should look like:
```
[<<] [1] [2] .... [21] [>>] 
```
