### PR TITLE
Added space between the calendar icon and the month name on sidebar

### DIFF
--- a/pelican-bootstrap3/templates/includes/sidebar/archive.html
+++ b/pelican-bootstrap3/templates/includes/sidebar/archive.html
@@ -10,7 +10,7 @@
         <li class="list-group-item">
           <a href="{{ SITEURL }}/{{ MONTH_ARCHIVE_SAVE_AS.format(date=articles[0].date) }}">
             {%- if not DISABLE_SIDEBAR_TITLE_ICONS -%}
-            <i class="fa fa-calendar fa-lg"></i>
+            <i class="fa fa-calendar fa-lg"></i>&nbsp;&nbsp;
             {%- endif -%}
             {{ articles[0].date.strftime('%B') }} {{ year }} ({{ articles|count }})
           </a>


### PR DESCRIPTION
On the Sidebar, when including Archives, the Calendar icon is touching the text of the month. I have added 2 spaces before the text (only when the icon is active)