### PR TITLE
pelican-bootstrap3: Add improved pagination

### DIFF
--- a/pelican-bootstrap3/README.md
+++ b/pelican-bootstrap3/README.md
@@ -148,6 +148,19 @@ the Bootstrap3 [Pagination
 component](http://getbootstrap.com/components/#pagination), but you can
 optionally use the Boostrap3 _Pager_ by setting `USE_PAGER` to `True`.
 
+Pelican-Bootstrap3 also have improved pagination.
+
+For enable this feature:
+- Set the flag `PAGINATION_BOOTSTRAP3_IMPROVED` to `True`
+- Add improved pagination theme plugin `PLUGIN_PATHS = (..., os.path.join(THEME, 'plugins'),)`
+- Activate improved pagination plugin `PLUGINS = (..., 'pagination',)`
+
+Available improved pagination options
+
+`PAGINATION_BOOTSTRAP3_IMPROVED`: `True` enable or `False` disable this feature
+`PAGINATION_BOOTSTRAP3_PAGES_TO_SHOW`: Number of pages in total, default value `11`
+`PAGINATION_BOOTSTRAP3_CSS_CLASSES`: Any extra CSS classes that should be added to the pagination `ul` element
+
 ### Bootstrap fluid layout
 
 If you'd like to use the fluid container layout from Bootstrap, set the flag

--- a/pelican-bootstrap3/jinja_filters/__init__.py
+++ b/pelican-bootstrap3/jinja_filters/__init__.py
@@ -1,0 +1,1 @@
+from .pagination import *

--- a/pelican-bootstrap3/jinja_filters/pagination.py
+++ b/pelican-bootstrap3/jinja_filters/pagination.py
@@ -1,0 +1,54 @@
+from math import floor
+
+#
+# Based on https://github.com/dyve/django-bootstrap3
+#
+
+def pagination(page, action):
+    pages_to_show = page.settings.get('PAGINATION_BOOTSTRAP3_PAGES_TO_SHOW', 11)
+    num_pages = page.paginator.num_pages
+    current_page = page.number
+
+    half_page_num = int(floor(pages_to_show / 2))
+    if half_page_num < 0:
+        half_page_num = 0
+    first_page = current_page - half_page_num
+    if first_page <= 1:
+        first_page = 1
+    if first_page > 1:
+        pages_back = first_page - half_page_num
+        if pages_back < 1:
+            pages_back = 1
+    else:
+        pages_back = None
+    last_page = first_page + pages_to_show - 1
+    if pages_back is None:
+        last_page += 1
+    if last_page > num_pages:
+        last_page = num_pages
+    if last_page < num_pages:
+        pages_forward = last_page + half_page_num
+        if pages_forward > num_pages:
+            pages_forward = num_pages
+    else:
+        pages_forward = None
+        if first_page > 1:
+            first_page -= 1
+        if pages_back is not None and pages_back > 1:
+            pages_back -= 1
+        else:
+            pages_back = None
+    pages_shown = []
+    for i in range(first_page, last_page + 1):
+        pages_shown.append(i)
+
+    if action == 'pages_back':
+        return pages_back
+    if action == 'pages_forward':
+        return pages_forward
+    if action == 'first_page':
+        return first_page
+    if action == 'last_page':
+        return last_page
+    if action == 'pages_shown':
+        return pages_shown

--- a/pelican-bootstrap3/plugins/__init__.py
+++ b/pelican-bootstrap3/plugins/__init__.py
@@ -1,0 +1,1 @@
+from .pagination import *

--- a/pelican-bootstrap3/plugins/pagination.py
+++ b/pelican-bootstrap3/plugins/pagination.py
@@ -1,0 +1,15 @@
+import os
+import sys
+from pelican import signals
+
+THEME_DIR = os.path.dirname(os.path.dirname(__file__))
+
+sys.path.append(THEME_DIR)
+import jinja_filters
+
+
+def pelican_init(pelicanobj):
+    pelicanobj.settings['JINJA_FILTERS'].update(pagination=jinja_filters.pagination)
+
+def register():
+    signals.initialized.connect(pelican_init)

--- a/pelican-bootstrap3/templates/includes/pagination.html
+++ b/pelican-bootstrap3/templates/includes/pagination.html
@@ -13,6 +13,33 @@
                 <li class="next disabled"><a href="#">{{ _('Older') }} &rarr;</a></li>
             {% endif %}
         </ul>
+    {% elif PAGINATION_BOOTSTRAP3_IMPROVED %}
+        <ul class="{{ 'pagination' if not PAGINATION_BOOTSTRAP3_CSS_CLASSES else PAGINATION_BOOTSTRAP3_CSS_CLASSES }}">
+            {% if articles_page.number == 1 %}
+                <li class="prev disabled"><a href="#">&laquo;</a></li>
+            {% else %}
+                <li class="prev"><a href="{{ SITEURL }}/{{ articles_paginator.page(1).url }}">&laquo;</a></li>
+            {% endif %}
+            {% set pages_back = articles_page|pagination('pages_back') %}
+            {% if pages_back %}
+                <li><a href="{{ SITEURL }}/{{ articles_paginator.page(pages_back).url }}">&hellip;</a></li>
+            {% endif %}
+
+            {% for num in articles_page|pagination('pages_shown') %}
+                <li{{ ' class="active"' if num == articles_page.number }}>
+                    <a href="{{ SITEURL }}/{{ articles_paginator.page(num).url if num > 1 else articles_paginator.page(1).url }}">{{ num }}</a>
+                </li>
+            {% endfor %}
+            {% set pages_forward = articles_page|pagination('pages_forward') %}
+            {% if pages_forward %}
+                <li><a href="{{ SITEURL }}/{{ articles_paginator.page(pages_forward).url }}">&hellip;</a></li>
+            {% endif %}
+            {% if articles_page.number == articles_paginator.num_pages %}
+                <li class="last disabled"><a href="#">&raquo;</a></li>
+            {% else %}
+                <li class="last"><a href="{{ SITEURL }}/{{ articles_paginator.page(articles_paginator.num_pages).url }}">&raquo;</a></li>
+            {% endif %}
+        </ul>
     {% else %}
         <ul class="pagination">
             {% if articles_page.has_previous() %}

--- a/pelican-bootstrap3/templates/includes/pagination.html
+++ b/pelican-bootstrap3/templates/includes/pagination.html
@@ -7,8 +7,7 @@
                 <li class="previous disabled"><a href="#">&larr; {{ _('Newer') }}</a></li>
             {% endif %}
             {% if articles_page.has_next() %}
-                <li class="next"><a
-                        href="{{ SITEURL }}/{{ articles_next_page.url }}">{{ _('Older') }} &rarr;</a></li>
+                <li class="next"><a href="{{ SITEURL }}/{{ articles_next_page.url }}">{{ _('Older') }} &rarr;</a></li>
             {% else %}
                 <li class="next disabled"><a href="#">{{ _('Older') }} &rarr;</a></li>
             {% endif %}
@@ -26,7 +25,7 @@
             {% endif %}
 
             {% for num in articles_page|pagination('pages_shown') %}
-                <li{{ ' class="active"' if num == articles_page.number }}>
+                <li{{ ' class="active"' if num == articles_page.number else '' }}>
                     <a href="{{ SITEURL }}/{{ articles_paginator.page(num).url if num > 1 else articles_paginator.page(1).url }}">{{ num }}</a>
                 </li>
             {% endfor %}
@@ -43,19 +42,17 @@
     {% else %}
         <ul class="pagination">
             {% if articles_page.has_previous() %}
-                {% set num = articles_page.previous_page_number() %}
-                <li class="prev"><a href="{{ SITEURL }}/{{ articles_previous_page.url }}">&laquo;</a>
-                </li>
+                <li class="prev"><a href="{{ SITEURL }}/{{ articles_previous_page.url }}">&laquo;</a></li>
             {% else %}
                 <li class="prev disabled"><a href="#">&laquo;</a></li>
             {% endif %}
             {% for num in range( 1, 1 + articles_paginator.num_pages ) %}
-                    <li class="{{ 'active' if num == articles_page.number else '' }}"><a
-                            href="{{ SITEURL }}/{{ articles_paginator.page(num).url if num > 1 else articles_paginator.page(1).url }}">{{ num }}</a></li>
+                    <li{{ ' class="active"' if num == articles_page.number else '' }}>
+                        <a href="{{ SITEURL }}/{{ articles_paginator.page(num).url if num > 1 else articles_paginator.page(1).url }}">{{ num }}</a>
+                    </li>
                 {% endfor %}
             {% if articles_page.has_next() %}
-                <li class="next"><a
-                        href="{{ SITEURL }}/{{ articles_next_page.url }}">&raquo;</a></li>
+                <li class="next"><a href="{{ SITEURL }}/{{ articles_next_page.url }}">&raquo;</a></li>
             {% else %}
                 <li class="next disabled"><a href="#">&raquo;</a></li>
             {% endif %}


### PR DESCRIPTION
If site have a lot of pages or articles default pagination show all pages and looks ugly.
This changes fix this problem.
