### PR TITLE
Add tag_cloud requirement to README.md

### DIFF
--- a/gum/README.md
+++ b/gum/README.md
@@ -9,6 +9,10 @@ Gum is a clean and responsive theme for [Pelican](https://github.com/getpelican/
 
 ### Configuration
 
+Make sure tag_cloud is listed in your PLUGINS
+
+PLUGINS = ["tag_cloud"]
+
 * Edit your settings file to include the following if desired (any values left blank won't show up in the theme):
 
 ```


### PR DESCRIPTION
List tag cloud plugin in README.

As a new pelican user I didn't know this was needed.

https://github.com/getpelican/pelican-themes/issues/560