### PR TITLE
GUM Theme - Only display "Pages" header if there are pages / menu items

### DIFF
--- a/gum/templates/sidebar.html
+++ b/gum/templates/sidebar.html
@@ -1,5 +1,6 @@
 <div class="three columns">
 
+{% if DISPLAY_PAGES_ON_MENU or DISPLAY_CATEGORIES_ON_MENU or MENUITEMS %}
 <h4>Pages</h4>
 
  <ul>
@@ -18,6 +19,7 @@
     {% endif %}
   {% endif %}
   </ul>
+{% endif %}
 
 <h4>Categories</h4>
 {% if categories %}


### PR DESCRIPTION
I was experimenting with a minimal site and noticed "Pages" displays even if there is nothing in that area.

This makes displaying the header conditional.