### PR TITLE
Pelican-bootstrap3: Fix pygments highlighting

### DIFF
--- a/pelican-bootstrap3/static/css/pygments/autumn.css
+++ b/pelican-bootstrap3/static/css/pygments/autumn.css
@@ -1,60 +1,60 @@
-.highlight pre .hll { background-color: #ffffcc }
-.highlight pre  { background: #ffffff; }
-.highlight pre .c { color: #aaaaaa; font-style: italic } /* Comment */
-.highlight pre .err { color: #FF0000; background-color: #FFAAAA } /* Error */
-.highlight pre .k { color: #0000aa } /* Keyword */
-.highlight pre .cm { color: #aaaaaa; font-style: italic } /* Comment.Multiline */
-.highlight pre .cp { color: #4c8317 } /* Comment.Preproc */
-.highlight pre .c1 { color: #aaaaaa; font-style: italic } /* Comment.Single */
-.highlight pre .cs { color: #0000aa; font-style: italic } /* Comment.Special */
-.highlight pre .gd { color: #aa0000 } /* Generic.Deleted */
-.highlight pre .ge { font-style: italic } /* Generic.Emph */
-.highlight pre .gr { color: #aa0000 } /* Generic.Error */
-.highlight pre .gh { color: #000080; font-weight: bold } /* Generic.Heading */
-.highlight pre .gi { color: #00aa00 } /* Generic.Inserted */
-.highlight pre .go { color: #888888 } /* Generic.Output */
-.highlight pre .gp { color: #555555 } /* Generic.Prompt */
-.highlight pre .gs { font-weight: bold } /* Generic.Strong */
-.highlight pre .gu { color: #800080; font-weight: bold } /* Generic.Subheading */
-.highlight pre .gt { color: #aa0000 } /* Generic.Traceback */
-.highlight pre .kc { color: #0000aa } /* Keyword.Constant */
-.highlight pre .kd { color: #0000aa } /* Keyword.Declaration */
-.highlight pre .kn { color: #0000aa } /* Keyword.Namespace */
-.highlight pre .kp { color: #0000aa } /* Keyword.Pseudo */
-.highlight pre .kr { color: #0000aa } /* Keyword.Reserved */
-.highlight pre .kt { color: #00aaaa } /* Keyword.Type */
-.highlight pre .m { color: #009999 } /* Literal.Number */
-.highlight pre .s { color: #aa5500 } /* Literal.String */
-.highlight pre .na { color: #1e90ff } /* Name.Attribute */
-.highlight pre .nb { color: #00aaaa } /* Name.Builtin */
-.highlight pre .nc { color: #00aa00; text-decoration: underline } /* Name.Class */
-.highlight pre .no { color: #aa0000 } /* Name.Constant */
-.highlight pre .nd { color: #888888 } /* Name.Decorator */
-.highlight pre .ni { color: #880000; font-weight: bold } /* Name.Entity */
-.highlight pre .nf { color: #00aa00 } /* Name.Function */
-.highlight pre .nn { color: #00aaaa; text-decoration: underline } /* Name.Namespace */
-.highlight pre .nt { color: #1e90ff; font-weight: bold } /* Name.Tag */
-.highlight pre .nv { color: #aa0000 } /* Name.Variable */
-.highlight pre .ow { color: #0000aa } /* Operator.Word */
-.highlight pre .w { color: #bbbbbb } /* Text.Whitespace */
-.highlight pre .mb { color: #009999 } /* Literal.Number.Bin */
-.highlight pre .mf { color: #009999 } /* Literal.Number.Float */
-.highlight pre .mh { color: #009999 } /* Literal.Number.Hex */
-.highlight pre .mi { color: #009999 } /* Literal.Number.Integer */
-.highlight pre .mo { color: #009999 } /* Literal.Number.Oct */
-.highlight pre .sb { color: #aa5500 } /* Literal.String.Backtick */
-.highlight pre .sc { color: #aa5500 } /* Literal.String.Char */
-.highlight pre .sd { color: #aa5500 } /* Literal.String.Doc */
-.highlight pre .s2 { color: #aa5500 } /* Literal.String.Double */
-.highlight pre .se { color: #aa5500 } /* Literal.String.Escape */
-.highlight pre .sh { color: #aa5500 } /* Literal.String.Heredoc */
-.highlight pre .si { color: #aa5500 } /* Literal.String.Interpol */
-.highlight pre .sx { color: #aa5500 } /* Literal.String.Other */
-.highlight pre .sr { color: #009999 } /* Literal.String.Regex */
-.highlight pre .s1 { color: #aa5500 } /* Literal.String.Single */
-.highlight pre .ss { color: #0000aa } /* Literal.String.Symbol */
-.highlight pre .bp { color: #00aaaa } /* Name.Builtin.Pseudo */
-.highlight pre .vc { color: #aa0000 } /* Name.Variable.Class */
-.highlight pre .vg { color: #aa0000 } /* Name.Variable.Global */
-.highlight pre .vi { color: #aa0000 } /* Name.Variable.Instance */
-.highlight pre .il { color: #009999 } /* Literal.Number.Integer.Long */
+.highlight pre .hll, pre.code .hll { background-color: #ffffcc }
+.highlight pre, pre.code { background: #ffffff; }
+.highlight pre .c, pre.code .c { color: #aaaaaa; font-style: italic } /* Comment */
+.highlight pre .err, pre.code .err { color: #FF0000; background-color: #FFAAAA } /* Error */
+.highlight pre .k, pre.code .k { color: #0000aa } /* Keyword */
+.highlight pre .cm, pre.code .cm { color: #aaaaaa; font-style: italic } /* Comment.Multiline */
+.highlight pre .cp, pre.code .cp { color: #4c8317 } /* Comment.Preproc */
+.highlight pre .c, pre.code .c1 { color: #aaaaaa; font-style: italic } /* Comment.Single */
+.highlight pre .cs, pre.code .cs { color: #0000aa; font-style: italic } /* Comment.Special */
+.highlight pre .gd, pre.code .gd { color: #aa0000 } /* Generic.Deleted */
+.highlight pre .ge, pre.code .ge { font-style: italic } /* Generic.Emph */
+.highlight pre .gr, pre.code .gr { color: #aa0000 } /* Generic.Error */
+.highlight pre .gh, pre.code .gh { color: #000080; font-weight: bold } /* Generic.Heading */
+.highlight pre .gi, pre.code .gi { color: #00aa00 } /* Generic.Inserted */
+.highlight pre .go, pre.code .go { color: #888888 } /* Generic.Output */
+.highlight pre .gp, pre.code .gp { color: #555555 } /* Generic.Prompt */
+.highlight pre .gs, pre.code .gs { font-weight: bold } /* Generic.Strong */
+.highlight pre .gu, pre.code .gu { color: #800080; font-weight: bold } /* Generic.Subheading */
+.highlight pre .gt, pre.code .gt { color: #aa0000 } /* Generic.Traceback */
+.highlight pre .kc, pre.code .kc { color: #0000aa } /* Keyword.Constant */
+.highlight pre .kd, pre.code .kd { color: #0000aa } /* Keyword.Declaration */
+.highlight pre .kn, pre.code .kn { color: #0000aa } /* Keyword.Namespace */
+.highlight pre .kp, pre.code .kp { color: #0000aa } /* Keyword.Pseudo */
+.highlight pre .kr, pre.code .kr { color: #0000aa } /* Keyword.Reserved */
+.highlight pre .kt, pre.code .kt { color: #00aaaa } /* Keyword.Type */
+.highlight pre .m, pre.code .m { color: #009999 } /* Literal.Number */
+.highlight pre .s, pre.code .s { color: #aa5500 } /* Literal.String */
+.highlight pre .na, pre.code .na { color: #1e90ff } /* Name.Attribute */
+.highlight pre .nb, pre.code .nb { color: #00aaaa } /* Name.Builtin */
+.highlight pre .nc, pre.code .nc { color: #00aa00; text-decoration: underline } /* Name.Class */
+.highlight pre .no, pre.code .no { color: #aa0000 } /* Name.Constant */
+.highlight pre .nd, pre.code .nd { color: #888888 } /* Name.Decorator */
+.highlight pre .ni, pre.code .ni { color: #880000; font-weight: bold } /* Name.Entity */
+.highlight pre .nf, pre.code .nf { color: #00aa00 } /* Name.Function */
+.highlight pre .nn, pre.code .nn { color: #00aaaa; text-decoration: underline } /* Name.Namespace */
+.highlight pre .nt, pre.code .nt { color: #1e90ff; font-weight: bold } /* Name.Tag */
+.highlight pre .nv, pre.code .nv { color: #aa0000 } /* Name.Variable */
+.highlight pre .ow, pre.code .ow { color: #0000aa } /* Operator.Word */
+.highlight pre .w, pre.code .w { color: #bbbbbb } /* Text.Whitespace */
+.highlight pre .mb, pre.code .mb { color: #009999 } /* Literal.Number.Bin */
+.highlight pre .mf, pre.code .mf { color: #009999 } /* Literal.Number.Float */
+.highlight pre .mh, pre.code .mh { color: #009999 } /* Literal.Number.Hex */
+.highlight pre .mi, pre.code .mi { color: #009999 } /* Literal.Number.Integer */
+.highlight pre .mo, pre.code .mo { color: #009999 } /* Literal.Number.Oct */
+.highlight pre .sb, pre.code .sb { color: #aa5500 } /* Literal.String.Backtick */
+.highlight pre .sc, pre.code .sc { color: #aa5500 } /* Literal.String.Char */
+.highlight pre .sd, pre.code .sd { color: #aa5500 } /* Literal.String.Doc */
+.highlight pre .s, pre.code .s2 { color: #aa5500 } /* Literal.String.Double */
+.highlight pre .se, pre.code .se { color: #aa5500 } /* Literal.String.Escape */
+.highlight pre .sh, pre.code .sh { color: #aa5500 } /* Literal.String.Heredoc */
+.highlight pre .si, pre.code .si { color: #aa5500 } /* Literal.String.Interpol */
+.highlight pre .sx, pre.code .sx { color: #aa5500 } /* Literal.String.Other */
+.highlight pre .sr, pre.code .sr { color: #009999 } /* Literal.String.Regex */
+.highlight pre .s, pre.code .s1 { color: #aa5500 } /* Literal.String.Single */
+.highlight pre .ss, pre.code .ss { color: #0000aa } /* Literal.String.Symbol */
+.highlight pre .bp, pre.code .bp { color: #00aaaa } /* Name.Builtin.Pseudo */
+.highlight pre .vc, pre.code .vc { color: #aa0000 } /* Name.Variable.Class */
+.highlight pre .vg, pre.code .vg { color: #aa0000 } /* Name.Variable.Global */
+.highlight pre .vi, pre.code .vi { color: #aa0000 } /* Name.Variable.Instance */
+.highlight pre .il, pre.code .il { color: #009999 } /* Literal.Number.Integer.Long */

--- a/pelican-bootstrap3/static/css/pygments/borland.css
+++ b/pelican-bootstrap3/static/css/pygments/borland.css
@@ -1,48 +1,48 @@
-.highlight pre .hll { background-color: #ffffcc }
-.highlight pre  { background: #ffffff; }
-.highlight pre .c { color: #008800; font-style: italic } /* Comment */
-.highlight pre .err { color: #a61717; background-color: #e3d2d2 } /* Error */
-.highlight pre .k { color: #000080; font-weight: bold } /* Keyword */
-.highlight pre .cm { color: #008800; font-style: italic } /* Comment.Multiline */
-.highlight pre .cp { color: #008080 } /* Comment.Preproc */
-.highlight pre .c1 { color: #008800; font-style: italic } /* Comment.Single */
-.highlight pre .cs { color: #008800; font-weight: bold } /* Comment.Special */
-.highlight pre .gd { color: #000000; background-color: #ffdddd } /* Generic.Deleted */
-.highlight pre .ge { font-style: italic } /* Generic.Emph */
-.highlight pre .gr { color: #aa0000 } /* Generic.Error */
-.highlight pre .gh { color: #999999 } /* Generic.Heading */
-.highlight pre .gi { color: #000000; background-color: #ddffdd } /* Generic.Inserted */
-.highlight pre .go { color: #888888 } /* Generic.Output */
-.highlight pre .gp { color: #555555 } /* Generic.Prompt */
-.highlight pre .gs { font-weight: bold } /* Generic.Strong */
-.highlight pre .gu { color: #aaaaaa } /* Generic.Subheading */
-.highlight pre .gt { color: #aa0000 } /* Generic.Traceback */
-.highlight pre .kc { color: #000080; font-weight: bold } /* Keyword.Constant */
-.highlight pre .kd { color: #000080; font-weight: bold } /* Keyword.Declaration */
-.highlight pre .kn { color: #000080; font-weight: bold } /* Keyword.Namespace */
-.highlight pre .kp { color: #000080; font-weight: bold } /* Keyword.Pseudo */
-.highlight pre .kr { color: #000080; font-weight: bold } /* Keyword.Reserved */
-.highlight pre .kt { color: #000080; font-weight: bold } /* Keyword.Type */
-.highlight pre .m { color: #0000FF } /* Literal.Number */
-.highlight pre .s { color: #0000FF } /* Literal.String */
-.highlight pre .na { color: #FF0000 } /* Name.Attribute */
-.highlight pre .nt { color: #000080; font-weight: bold } /* Name.Tag */
-.highlight pre .ow { font-weight: bold } /* Operator.Word */
-.highlight pre .w { color: #bbbbbb } /* Text.Whitespace */
-.highlight pre .mb { color: #0000FF } /* Literal.Number.Bin */
-.highlight pre .mf { color: #0000FF } /* Literal.Number.Float */
-.highlight pre .mh { color: #0000FF } /* Literal.Number.Hex */
-.highlight pre .mi { color: #0000FF } /* Literal.Number.Integer */
-.highlight pre .mo { color: #0000FF } /* Literal.Number.Oct */
-.highlight pre .sb { color: #0000FF } /* Literal.String.Backtick */
-.highlight pre .sc { color: #800080 } /* Literal.String.Char */
-.highlight pre .sd { color: #0000FF } /* Literal.String.Doc */
-.highlight pre .s2 { color: #0000FF } /* Literal.String.Double */
-.highlight pre .se { color: #0000FF } /* Literal.String.Escape */
-.highlight pre .sh { color: #0000FF } /* Literal.String.Heredoc */
-.highlight pre .si { color: #0000FF } /* Literal.String.Interpol */
-.highlight pre .sx { color: #0000FF } /* Literal.String.Other */
-.highlight pre .sr { color: #0000FF } /* Literal.String.Regex */
-.highlight pre .s1 { color: #0000FF } /* Literal.String.Single */
-.highlight pre .ss { color: #0000FF } /* Literal.String.Symbol */
-.highlight pre .il { color: #0000FF } /* Literal.Number.Integer.Long */
+.highlight pre .hll, pre.code .hll { background-color: #ffffcc }
+.highlight pre, pre.code { background: #ffffff; }
+.highlight pre .c, pre.code .c { color: #008800; font-style: italic } /* Comment */
+.highlight pre .err, pre.code .err { color: #a61717; background-color: #e3d2d2 } /* Error */
+.highlight pre .k, pre.code .k { color: #000080; font-weight: bold } /* Keyword */
+.highlight pre .cm, pre.code .cm { color: #008800; font-style: italic } /* Comment.Multiline */
+.highlight pre .cp, pre.code .cp { color: #008080 } /* Comment.Preproc */
+.highlight pre .c, pre.code .c1 { color: #008800; font-style: italic } /* Comment.Single */
+.highlight pre .cs, pre.code .cs { color: #008800; font-weight: bold } /* Comment.Special */
+.highlight pre .gd, pre.code .gd { color: #000000; background-color: #ffdddd } /* Generic.Deleted */
+.highlight pre .ge, pre.code .ge { font-style: italic } /* Generic.Emph */
+.highlight pre .gr, pre.code .gr { color: #aa0000 } /* Generic.Error */
+.highlight pre .gh, pre.code .gh { color: #999999 } /* Generic.Heading */
+.highlight pre .gi, pre.code .gi { color: #000000; background-color: #ddffdd } /* Generic.Inserted */
+.highlight pre .go, pre.code .go { color: #888888 } /* Generic.Output */
+.highlight pre .gp, pre.code .gp { color: #555555 } /* Generic.Prompt */
+.highlight pre .gs, pre.code .gs { font-weight: bold } /* Generic.Strong */
+.highlight pre .gu, pre.code .gu { color: #aaaaaa } /* Generic.Subheading */
+.highlight pre .gt, pre.code .gt { color: #aa0000 } /* Generic.Traceback */
+.highlight pre .kc, pre.code .kc { color: #000080; font-weight: bold } /* Keyword.Constant */
+.highlight pre .kd, pre.code .kd { color: #000080; font-weight: bold } /* Keyword.Declaration */
+.highlight pre .kn, pre.code .kn { color: #000080; font-weight: bold } /* Keyword.Namespace */
+.highlight pre .kp, pre.code .kp { color: #000080; font-weight: bold } /* Keyword.Pseudo */
+.highlight pre .kr, pre.code .kr { color: #000080; font-weight: bold } /* Keyword.Reserved */
+.highlight pre .kt, pre.code .kt { color: #000080; font-weight: bold } /* Keyword.Type */
+.highlight pre .m, pre.code .m { color: #0000FF } /* Literal.Number */
+.highlight pre .s, pre.code .s { color: #0000FF } /* Literal.String */
+.highlight pre .na, pre.code .na { color: #FF0000 } /* Name.Attribute */
+.highlight pre .nt, pre.code .nt { color: #000080; font-weight: bold } /* Name.Tag */
+.highlight pre .ow, pre.code .ow { font-weight: bold } /* Operator.Word */
+.highlight pre .w, pre.code .w { color: #bbbbbb } /* Text.Whitespace */
+.highlight pre .mb, pre.code .mb { color: #0000FF } /* Literal.Number.Bin */
+.highlight pre .mf, pre.code .mf { color: #0000FF } /* Literal.Number.Float */
+.highlight pre .mh, pre.code .mh { color: #0000FF } /* Literal.Number.Hex */
+.highlight pre .mi, pre.code .mi { color: #0000FF } /* Literal.Number.Integer */
+.highlight pre .mo, pre.code .mo { color: #0000FF } /* Literal.Number.Oct */
+.highlight pre .sb, pre.code .sb { color: #0000FF } /* Literal.String.Backtick */
+.highlight pre .sc, pre.code .sc { color: #800080 } /* Literal.String.Char */
+.highlight pre .sd, pre.code .sd { color: #0000FF } /* Literal.String.Doc */
+.highlight pre .s, pre.code .s2 { color: #0000FF } /* Literal.String.Double */
+.highlight pre .se, pre.code .se { color: #0000FF } /* Literal.String.Escape */
+.highlight pre .sh, pre.code .sh { color: #0000FF } /* Literal.String.Heredoc */
+.highlight pre .si, pre.code .si { color: #0000FF } /* Literal.String.Interpol */
+.highlight pre .sx, pre.code .sx { color: #0000FF } /* Literal.String.Other */
+.highlight pre .sr, pre.code .sr { color: #0000FF } /* Literal.String.Regex */
+.highlight pre .s, pre.code .s1 { color: #0000FF } /* Literal.String.Single */
+.highlight pre .ss, pre.code .ss { color: #0000FF } /* Literal.String.Symbol */
+.highlight pre .il, pre.code .il { color: #0000FF } /* Literal.Number.Integer.Long */

--- a/pelican-bootstrap3/static/css/pygments/bw.css
+++ b/pelican-bootstrap3/static/css/pygments/bw.css
@@ -1,35 +1,35 @@
-.highlight pre .hll { background-color: #ffffcc }
-.highlight pre  { background: #ffffff; }
-.highlight pre .c { font-style: italic } /* Comment */
-.highlight pre .err { border: 1px solid #FF0000 } /* Error */
-.highlight pre .k { font-weight: bold } /* Keyword */
-.highlight pre .cm { font-style: italic } /* Comment.Multiline */
-.highlight pre .c1 { font-style: italic } /* Comment.Single */
-.highlight pre .cs { font-style: italic } /* Comment.Special */
-.highlight pre .ge { font-style: italic } /* Generic.Emph */
-.highlight pre .gh { font-weight: bold } /* Generic.Heading */
-.highlight pre .gp { font-weight: bold } /* Generic.Prompt */
-.highlight pre .gs { font-weight: bold } /* Generic.Strong */
-.highlight pre .gu { font-weight: bold } /* Generic.Subheading */
-.highlight pre .kc { font-weight: bold } /* Keyword.Constant */
-.highlight pre .kd { font-weight: bold } /* Keyword.Declaration */
-.highlight pre .kn { font-weight: bold } /* Keyword.Namespace */
-.highlight pre .kr { font-weight: bold } /* Keyword.Reserved */
-.highlight pre .s { font-style: italic } /* Literal.String */
-.highlight pre .nc { font-weight: bold } /* Name.Class */
-.highlight pre .ni { font-weight: bold } /* Name.Entity */
-.highlight pre .ne { font-weight: bold } /* Name.Exception */
-.highlight pre .nn { font-weight: bold } /* Name.Namespace */
-.highlight pre .nt { font-weight: bold } /* Name.Tag */
-.highlight pre .ow { font-weight: bold } /* Operator.Word */
-.highlight pre .sb { font-style: italic } /* Literal.String.Backtick */
-.highlight pre .sc { font-style: italic } /* Literal.String.Char */
-.highlight pre .sd { font-style: italic } /* Literal.String.Doc */
-.highlight pre .s2 { font-style: italic } /* Literal.String.Double */
-.highlight pre .se { font-weight: bold; font-style: italic } /* Literal.String.Escape */
-.highlight pre .sh { font-style: italic } /* Literal.String.Heredoc */
-.highlight pre .si { font-weight: bold; font-style: italic } /* Literal.String.Interpol */
-.highlight pre .sx { font-style: italic } /* Literal.String.Other */
-.highlight pre .sr { font-style: italic } /* Literal.String.Regex */
-.highlight pre .s1 { font-style: italic } /* Literal.String.Single */
-.highlight pre .ss { font-style: italic } /* Literal.String.Symbol */
+.highlight pre .hll, pre.code .hll { background-color: #ffffcc }
+.highlight pre, pre.code { background: #ffffff; }
+.highlight pre .c, pre.code .c { font-style: italic } /* Comment */
+.highlight pre .err, pre.code .err { border: 1px solid #FF0000 } /* Error */
+.highlight pre .k, pre.code .k { font-weight: bold } /* Keyword */
+.highlight pre .cm, pre.code .cm { font-style: italic } /* Comment.Multiline */
+.highlight pre .c, pre.code .c1 { font-style: italic } /* Comment.Single */
+.highlight pre .cs, pre.code .cs { font-style: italic } /* Comment.Special */
+.highlight pre .ge, pre.code .ge { font-style: italic } /* Generic.Emph */
+.highlight pre .gh, pre.code .gh { font-weight: bold } /* Generic.Heading */
+.highlight pre .gp, pre.code .gp { font-weight: bold } /* Generic.Prompt */
+.highlight pre .gs, pre.code .gs { font-weight: bold } /* Generic.Strong */
+.highlight pre .gu, pre.code .gu { font-weight: bold } /* Generic.Subheading */
+.highlight pre .kc, pre.code .kc { font-weight: bold } /* Keyword.Constant */
+.highlight pre .kd, pre.code .kd { font-weight: bold } /* Keyword.Declaration */
+.highlight pre .kn, pre.code .kn { font-weight: bold } /* Keyword.Namespace */
+.highlight pre .kr, pre.code .kr { font-weight: bold } /* Keyword.Reserved */
+.highlight pre .s, pre.code .s { font-style: italic } /* Literal.String */
+.highlight pre .nc, pre.code .nc { font-weight: bold } /* Name.Class */
+.highlight pre .ni, pre.code .ni { font-weight: bold } /* Name.Entity */
+.highlight pre .ne, pre.code .ne { font-weight: bold } /* Name.Exception */
+.highlight pre .nn, pre.code .nn { font-weight: bold } /* Name.Namespace */
+.highlight pre .nt, pre.code .nt { font-weight: bold } /* Name.Tag */
+.highlight pre .ow, pre.code .ow { font-weight: bold } /* Operator.Word */
+.highlight pre .sb, pre.code .sb { font-style: italic } /* Literal.String.Backtick */
+.highlight pre .sc, pre.code .sc { font-style: italic } /* Literal.String.Char */
+.highlight pre .sd, pre.code .sd { font-style: italic } /* Literal.String.Doc */
+.highlight pre .s, pre.code .s2 { font-style: italic } /* Literal.String.Double */
+.highlight pre .se, pre.code .se { font-weight: bold; font-style: italic } /* Literal.String.Escape */
+.highlight pre .sh, pre.code .sh { font-style: italic } /* Literal.String.Heredoc */
+.highlight pre .si, pre.code .si { font-weight: bold; font-style: italic } /* Literal.String.Interpol */
+.highlight pre .sx, pre.code .sx { font-style: italic } /* Literal.String.Other */
+.highlight pre .sr, pre.code .sr { font-style: italic } /* Literal.String.Regex */
+.highlight pre .s, pre.code .s1 { font-style: italic } /* Literal.String.Single */
+.highlight pre .ss, pre.code .ss { font-style: italic } /* Literal.String.Symbol */

--- a/pelican-bootstrap3/static/css/pygments/colorful.css
+++ b/pelican-bootstrap3/static/css/pygments/colorful.css
@@ -1,63 +1,63 @@
-.highlight pre .hll { background-color: #ffffcc }
-.highlight pre  { background: #ffffff; }
-.highlight pre .c { color: #888888 } /* Comment */
-.highlight pre .err { color: #FF0000; background-color: #FFAAAA } /* Error */
-.highlight pre .k { color: #008800; font-weight: bold } /* Keyword */
-.highlight pre .o { color: #333333 } /* Operator */
-.highlight pre .cm { color: #888888 } /* Comment.Multiline */
-.highlight pre .cp { color: #557799 } /* Comment.Preproc */
-.highlight pre .c1 { color: #888888 } /* Comment.Single */
-.highlight pre .cs { color: #cc0000; font-weight: bold } /* Comment.Special */
-.highlight pre .gd { color: #A00000 } /* Generic.Deleted */
-.highlight pre .ge { font-style: italic } /* Generic.Emph */
-.highlight pre .gr { color: #FF0000 } /* Generic.Error */
-.highlight pre .gh { color: #000080; font-weight: bold } /* Generic.Heading */
-.highlight pre .gi { color: #00A000 } /* Generic.Inserted */
-.highlight pre .go { color: #888888 } /* Generic.Output */
-.highlight pre .gp { color: #c65d09; font-weight: bold } /* Generic.Prompt */
-.highlight pre .gs { font-weight: bold } /* Generic.Strong */
-.highlight pre .gu { color: #800080; font-weight: bold } /* Generic.Subheading */
-.highlight pre .gt { color: #0044DD } /* Generic.Traceback */
-.highlight pre .kc { color: #008800; font-weight: bold } /* Keyword.Constant */
-.highlight pre .kd { color: #008800; font-weight: bold } /* Keyword.Declaration */
-.highlight pre .kn { color: #008800; font-weight: bold } /* Keyword.Namespace */
-.highlight pre .kp { color: #003388; font-weight: bold } /* Keyword.Pseudo */
-.highlight pre .kr { color: #008800; font-weight: bold } /* Keyword.Reserved */
-.highlight pre .kt { color: #333399; font-weight: bold } /* Keyword.Type */
-.highlight pre .m { color: #6600EE; font-weight: bold } /* Literal.Number */
-.highlight pre .s { background-color: #fff0f0 } /* Literal.String */
-.highlight pre .na { color: #0000CC } /* Name.Attribute */
-.highlight pre .nb { color: #007020 } /* Name.Builtin */
-.highlight pre .nc { color: #BB0066; font-weight: bold } /* Name.Class */
-.highlight pre .no { color: #003366; font-weight: bold } /* Name.Constant */
-.highlight pre .nd { color: #555555; font-weight: bold } /* Name.Decorator */
-.highlight pre .ni { color: #880000; font-weight: bold } /* Name.Entity */
-.highlight pre .ne { color: #FF0000; font-weight: bold } /* Name.Exception */
-.highlight pre .nf { color: #0066BB; font-weight: bold } /* Name.Function */
-.highlight pre .nl { color: #997700; font-weight: bold } /* Name.Label */
-.highlight pre .nn { color: #0e84b5; font-weight: bold } /* Name.Namespace */
-.highlight pre .nt { color: #007700 } /* Name.Tag */
-.highlight pre .nv { color: #996633 } /* Name.Variable */
-.highlight pre .ow { color: #000000; font-weight: bold } /* Operator.Word */
-.highlight pre .w { color: #bbbbbb } /* Text.Whitespace */
-.highlight pre .mb { color: #6600EE; font-weight: bold } /* Literal.Number.Bin */
-.highlight pre .mf { color: #6600EE; font-weight: bold } /* Literal.Number.Float */
-.highlight pre .mh { color: #005588; font-weight: bold } /* Literal.Number.Hex */
-.highlight pre .mi { color: #0000DD; font-weight: bold } /* Literal.Number.Integer */
-.highlight pre .mo { color: #4400EE; font-weight: bold } /* Literal.Number.Oct */
-.highlight pre .sb { background-color: #fff0f0 } /* Literal.String.Backtick */
-.highlight pre .sc { color: #0044DD } /* Literal.String.Char */
-.highlight pre .sd { color: #DD4422 } /* Literal.String.Doc */
-.highlight pre .s2 { background-color: #fff0f0 } /* Literal.String.Double */
-.highlight pre .se { color: #666666; font-weight: bold; background-color: #fff0f0 } /* Literal.String.Escape */
-.highlight pre .sh { background-color: #fff0f0 } /* Literal.String.Heredoc */
-.highlight pre .si { background-color: #eeeeee } /* Literal.String.Interpol */
-.highlight pre .sx { color: #DD2200; background-color: #fff0f0 } /* Literal.String.Other */
-.highlight pre .sr { color: #000000; background-color: #fff0ff } /* Literal.String.Regex */
-.highlight pre .s1 { background-color: #fff0f0 } /* Literal.String.Single */
-.highlight pre .ss { color: #AA6600 } /* Literal.String.Symbol */
-.highlight pre .bp { color: #007020 } /* Name.Builtin.Pseudo */
-.highlight pre .vc { color: #336699 } /* Name.Variable.Class */
-.highlight pre .vg { color: #dd7700; font-weight: bold } /* Name.Variable.Global */
-.highlight pre .vi { color: #3333BB } /* Name.Variable.Instance */
-.highlight pre .il { color: #0000DD; font-weight: bold } /* Literal.Number.Integer.Long */
+.highlight pre .hll, pre.code .hll { background-color: #ffffcc }
+.highlight pre, pre.code { background: #ffffff; }
+.highlight pre .c, pre.code .c { color: #888888 } /* Comment */
+.highlight pre .err, pre.code .err { color: #FF0000; background-color: #FFAAAA } /* Error */
+.highlight pre .k, pre.code .k { color: #008800; font-weight: bold } /* Keyword */
+.highlight pre .o, pre.code .o { color: #333333 } /* Operator */
+.highlight pre .cm, pre.code .cm { color: #888888 } /* Comment.Multiline */
+.highlight pre .cp, pre.code .cp { color: #557799 } /* Comment.Preproc */
+.highlight pre .c, pre.code .c1 { color: #888888 } /* Comment.Single */
+.highlight pre .cs, pre.code .cs { color: #cc0000; font-weight: bold } /* Comment.Special */
+.highlight pre .gd, pre.code .gd { color: #A00000 } /* Generic.Deleted */
+.highlight pre .ge, pre.code .ge { font-style: italic } /* Generic.Emph */
+.highlight pre .gr, pre.code .gr { color: #FF0000 } /* Generic.Error */
+.highlight pre .gh, pre.code .gh { color: #000080; font-weight: bold } /* Generic.Heading */
+.highlight pre .gi, pre.code .gi { color: #00A000 } /* Generic.Inserted */
+.highlight pre .go, pre.code .go { color: #888888 } /* Generic.Output */
+.highlight pre .gp, pre.code .gp { color: #c65d09; font-weight: bold } /* Generic.Prompt */
+.highlight pre .gs, pre.code .gs { font-weight: bold } /* Generic.Strong */
+.highlight pre .gu, pre.code .gu { color: #800080; font-weight: bold } /* Generic.Subheading */
+.highlight pre .gt, pre.code .gt { color: #0044DD } /* Generic.Traceback */
+.highlight pre .kc, pre.code .kc { color: #008800; font-weight: bold } /* Keyword.Constant */
+.highlight pre .kd, pre.code .kd { color: #008800; font-weight: bold } /* Keyword.Declaration */
+.highlight pre .kn, pre.code .kn { color: #008800; font-weight: bold } /* Keyword.Namespace */
+.highlight pre .kp, pre.code .kp { color: #003388; font-weight: bold } /* Keyword.Pseudo */
+.highlight pre .kr, pre.code .kr { color: #008800; font-weight: bold } /* Keyword.Reserved */
+.highlight pre .kt, pre.code .kt { color: #333399; font-weight: bold } /* Keyword.Type */
+.highlight pre .m, pre.code .m { color: #6600EE; font-weight: bold } /* Literal.Number */
+.highlight pre .s, pre.code .s { background-color: #fff0f0 } /* Literal.String */
+.highlight pre .na, pre.code .na { color: #0000CC } /* Name.Attribute */
+.highlight pre .nb, pre.code .nb { color: #007020 } /* Name.Builtin */
+.highlight pre .nc, pre.code .nc { color: #BB0066; font-weight: bold } /* Name.Class */
+.highlight pre .no, pre.code .no { color: #003366; font-weight: bold } /* Name.Constant */
+.highlight pre .nd, pre.code .nd { color: #555555; font-weight: bold } /* Name.Decorator */
+.highlight pre .ni, pre.code .ni { color: #880000; font-weight: bold } /* Name.Entity */
+.highlight pre .ne, pre.code .ne { color: #FF0000; font-weight: bold } /* Name.Exception */
+.highlight pre .nf, pre.code .nf { color: #0066BB; font-weight: bold } /* Name.Function */
+.highlight pre .nl, pre.code .nl { color: #997700; font-weight: bold } /* Name.Label */
+.highlight pre .nn, pre.code .nn { color: #0e84b5; font-weight: bold } /* Name.Namespace */
+.highlight pre .nt, pre.code .nt { color: #007700 } /* Name.Tag */
+.highlight pre .nv, pre.code .nv { color: #996633 } /* Name.Variable */
+.highlight pre .ow, pre.code .ow { color: #000000; font-weight: bold } /* Operator.Word */
+.highlight pre .w, pre.code .w { color: #bbbbbb } /* Text.Whitespace */
+.highlight pre .mb, pre.code .mb { color: #6600EE; font-weight: bold } /* Literal.Number.Bin */
+.highlight pre .mf, pre.code .mf { color: #6600EE; font-weight: bold } /* Literal.Number.Float */
+.highlight pre .mh, pre.code .mh { color: #005588; font-weight: bold } /* Literal.Number.Hex */
+.highlight pre .mi, pre.code .mi { color: #0000DD; font-weight: bold } /* Literal.Number.Integer */
+.highlight pre .mo, pre.code .mo { color: #4400EE; font-weight: bold } /* Literal.Number.Oct */
+.highlight pre .sb, pre.code .sb { background-color: #fff0f0 } /* Literal.String.Backtick */
+.highlight pre .sc, pre.code .sc { color: #0044DD } /* Literal.String.Char */
+.highlight pre .sd, pre.code .sd { color: #DD4422 } /* Literal.String.Doc */
+.highlight pre .s, pre.code .s2 { background-color: #fff0f0 } /* Literal.String.Double */
+.highlight pre .se, pre.code .se { color: #666666; font-weight: bold; background-color: #fff0f0 } /* Literal.String.Escape */
+.highlight pre .sh, pre.code .sh { background-color: #fff0f0 } /* Literal.String.Heredoc */
+.highlight pre .si, pre.code .si { background-color: #eeeeee } /* Literal.String.Interpol */
+.highlight pre .sx, pre.code .sx { color: #DD2200; background-color: #fff0f0 } /* Literal.String.Other */
+.highlight pre .sr, pre.code .sr { color: #000000; background-color: #fff0ff } /* Literal.String.Regex */
+.highlight pre .s, pre.code .s1 { background-color: #fff0f0 } /* Literal.String.Single */
+.highlight pre .ss, pre.code .ss { color: #AA6600 } /* Literal.String.Symbol */
+.highlight pre .bp, pre.code .bp { color: #007020 } /* Name.Builtin.Pseudo */
+.highlight pre .vc, pre.code .vc { color: #336699 } /* Name.Variable.Class */
+.highlight pre .vg, pre.code .vg { color: #dd7700; font-weight: bold } /* Name.Variable.Global */
+.highlight pre .vi, pre.code .vi { color: #3333BB } /* Name.Variable.Instance */
+.highlight pre .il, pre.code .il { color: #0000DD; font-weight: bold } /* Literal.Number.Integer.Long */

--- a/pelican-bootstrap3/static/css/pygments/default.css
+++ b/pelican-bootstrap3/static/css/pygments/default.css
@@ -1,63 +1,63 @@
-.highlight pre .hll { background-color: #ffffcc }
-.highlight pre  { background: #f8f8f8; }
-.highlight pre .c { color: #408080; font-style: italic } /* Comment */
-.highlight pre .err { border: 1px solid #FF0000 } /* Error */
-.highlight pre .k { color: #008000; font-weight: bold } /* Keyword */
-.highlight pre .o { color: #666666 } /* Operator */
-.highlight pre .cm { color: #408080; font-style: italic } /* Comment.Multiline */
-.highlight pre .cp { color: #BC7A00 } /* Comment.Preproc */
-.highlight pre .c1 { color: #408080; font-style: italic } /* Comment.Single */
-.highlight pre .cs { color: #408080; font-style: italic } /* Comment.Special */
-.highlight pre .gd { color: #A00000 } /* Generic.Deleted */
-.highlight pre .ge { font-style: italic } /* Generic.Emph */
-.highlight pre .gr { color: #FF0000 } /* Generic.Error */
-.highlight pre .gh { color: #000080; font-weight: bold } /* Generic.Heading */
-.highlight pre .gi { color: #00A000 } /* Generic.Inserted */
-.highlight pre .go { color: #888888 } /* Generic.Output */
-.highlight pre .gp { color: #000080; font-weight: bold } /* Generic.Prompt */
-.highlight pre .gs { font-weight: bold } /* Generic.Strong */
-.highlight pre .gu { color: #800080; font-weight: bold } /* Generic.Subheading */
-.highlight pre .gt { color: #0044DD } /* Generic.Traceback */
-.highlight pre .kc { color: #008000; font-weight: bold } /* Keyword.Constant */
-.highlight pre .kd { color: #008000; font-weight: bold } /* Keyword.Declaration */
-.highlight pre .kn { color: #008000; font-weight: bold } /* Keyword.Namespace */
-.highlight pre .kp { color: #008000 } /* Keyword.Pseudo */
-.highlight pre .kr { color: #008000; font-weight: bold } /* Keyword.Reserved */
-.highlight pre .kt { color: #B00040 } /* Keyword.Type */
-.highlight pre .m { color: #666666 } /* Literal.Number */
-.highlight pre .s { color: #BA2121 } /* Literal.String */
-.highlight pre .na { color: #7D9029 } /* Name.Attribute */
-.highlight pre .nb { color: #008000 } /* Name.Builtin */
-.highlight pre .nc { color: #0000FF; font-weight: bold } /* Name.Class */
-.highlight pre .no { color: #880000 } /* Name.Constant */
-.highlight pre .nd { color: #AA22FF } /* Name.Decorator */
-.highlight pre .ni { color: #999999; font-weight: bold } /* Name.Entity */
-.highlight pre .ne { color: #D2413A; font-weight: bold } /* Name.Exception */
-.highlight pre .nf { color: #0000FF } /* Name.Function */
-.highlight pre .nl { color: #A0A000 } /* Name.Label */
-.highlight pre .nn { color: #0000FF; font-weight: bold } /* Name.Namespace */
-.highlight pre .nt { color: #008000; font-weight: bold } /* Name.Tag */
-.highlight pre .nv { color: #19177C } /* Name.Variable */
-.highlight pre .ow { color: #AA22FF; font-weight: bold } /* Operator.Word */
-.highlight pre .w { color: #bbbbbb } /* Text.Whitespace */
-.highlight pre .mb { color: #666666 } /* Literal.Number.Bin */
-.highlight pre .mf { color: #666666 } /* Literal.Number.Float */
-.highlight pre .mh { color: #666666 } /* Literal.Number.Hex */
-.highlight pre .mi { color: #666666 } /* Literal.Number.Integer */
-.highlight pre .mo { color: #666666 } /* Literal.Number.Oct */
-.highlight pre .sb { color: #BA2121 } /* Literal.String.Backtick */
-.highlight pre .sc { color: #BA2121 } /* Literal.String.Char */
-.highlight pre .sd { color: #BA2121; font-style: italic } /* Literal.String.Doc */
-.highlight pre .s2 { color: #BA2121 } /* Literal.String.Double */
-.highlight pre .se { color: #BB6622; font-weight: bold } /* Literal.String.Escape */
-.highlight pre .sh { color: #BA2121 } /* Literal.String.Heredoc */
-.highlight pre .si { color: #BB6688; font-weight: bold } /* Literal.String.Interpol */
-.highlight pre .sx { color: #008000 } /* Literal.String.Other */
-.highlight pre .sr { color: #BB6688 } /* Literal.String.Regex */
-.highlight pre .s1 { color: #BA2121 } /* Literal.String.Single */
-.highlight pre .ss { color: #19177C } /* Literal.String.Symbol */
-.highlight pre .bp { color: #008000 } /* Name.Builtin.Pseudo */
-.highlight pre .vc { color: #19177C } /* Name.Variable.Class */
-.highlight pre .vg { color: #19177C } /* Name.Variable.Global */
-.highlight pre .vi { color: #19177C } /* Name.Variable.Instance */
-.highlight pre .il { color: #666666 } /* Literal.Number.Integer.Long */
+.highlight pre .hll, pre.code .hll { background-color: #ffffcc }
+.highlight pre, pre.code { background: #f8f8f8; }
+.highlight pre .c, pre.code .c { color: #408080; font-style: italic } /* Comment */
+.highlight pre .err, pre.code .err { border: 1px solid #FF0000 } /* Error */
+.highlight pre .k, pre.code .k { color: #008000; font-weight: bold } /* Keyword */
+.highlight pre .o, pre.code .o { color: #666666 } /* Operator */
+.highlight pre .cm, pre.code .cm { color: #408080; font-style: italic } /* Comment.Multiline */
+.highlight pre .cp, pre.code .cp { color: #BC7A00 } /* Comment.Preproc */
+.highlight pre .c, pre.code .c1 { color: #408080; font-style: italic } /* Comment.Single */
+.highlight pre .cs, pre.code .cs { color: #408080; font-style: italic } /* Comment.Special */
+.highlight pre .gd, pre.code .gd { color: #A00000 } /* Generic.Deleted */
+.highlight pre .ge, pre.code .ge { font-style: italic } /* Generic.Emph */
+.highlight pre .gr, pre.code .gr { color: #FF0000 } /* Generic.Error */
+.highlight pre .gh, pre.code .gh { color: #000080; font-weight: bold } /* Generic.Heading */
+.highlight pre .gi, pre.code .gi { color: #00A000 } /* Generic.Inserted */
+.highlight pre .go, pre.code .go { color: #888888 } /* Generic.Output */
+.highlight pre .gp, pre.code .gp { color: #000080; font-weight: bold } /* Generic.Prompt */
+.highlight pre .gs, pre.code .gs { font-weight: bold } /* Generic.Strong */
+.highlight pre .gu, pre.code .gu { color: #800080; font-weight: bold } /* Generic.Subheading */
+.highlight pre .gt, pre.code .gt { color: #0044DD } /* Generic.Traceback */
+.highlight pre .kc, pre.code .kc { color: #008000; font-weight: bold } /* Keyword.Constant */
+.highlight pre .kd, pre.code .kd { color: #008000; font-weight: bold } /* Keyword.Declaration */
+.highlight pre .kn, pre.code .kn { color: #008000; font-weight: bold } /* Keyword.Namespace */
+.highlight pre .kp, pre.code .kp { color: #008000 } /* Keyword.Pseudo */
+.highlight pre .kr, pre.code .kr { color: #008000; font-weight: bold } /* Keyword.Reserved */
+.highlight pre .kt, pre.code .kt { color: #B00040 } /* Keyword.Type */
+.highlight pre .m, pre.code .m { color: #666666 } /* Literal.Number */
+.highlight pre .s, pre.code .s { color: #BA2121 } /* Literal.String */
+.highlight pre .na, pre.code .na { color: #7D9029 } /* Name.Attribute */
+.highlight pre .nb, pre.code .nb { color: #008000 } /* Name.Builtin */
+.highlight pre .nc, pre.code .nc { color: #0000FF; font-weight: bold } /* Name.Class */
+.highlight pre .no, pre.code .no { color: #880000 } /* Name.Constant */
+.highlight pre .nd, pre.code .nd { color: #AA22FF } /* Name.Decorator */
+.highlight pre .ni, pre.code .ni { color: #999999; font-weight: bold } /* Name.Entity */
+.highlight pre .ne, pre.code .ne { color: #D2413A; font-weight: bold } /* Name.Exception */
+.highlight pre .nf, pre.code .nf { color: #0000FF } /* Name.Function */
+.highlight pre .nl, pre.code .nl { color: #A0A000 } /* Name.Label */
+.highlight pre .nn, pre.code .nn { color: #0000FF; font-weight: bold } /* Name.Namespace */
+.highlight pre .nt, pre.code .nt { color: #008000; font-weight: bold } /* Name.Tag */
+.highlight pre .nv, pre.code .nv { color: #19177C } /* Name.Variable */
+.highlight pre .ow, pre.code .ow { color: #AA22FF; font-weight: bold } /* Operator.Word */
+.highlight pre .w, pre.code .w { color: #bbbbbb } /* Text.Whitespace */
+.highlight pre .mb, pre.code .mb { color: #666666 } /* Literal.Number.Bin */
+.highlight pre .mf, pre.code .mf { color: #666666 } /* Literal.Number.Float */
+.highlight pre .mh, pre.code .mh { color: #666666 } /* Literal.Number.Hex */
+.highlight pre .mi, pre.code .mi { color: #666666 } /* Literal.Number.Integer */
+.highlight pre .mo, pre.code .mo { color: #666666 } /* Literal.Number.Oct */
+.highlight pre .sb, pre.code .sb { color: #BA2121 } /* Literal.String.Backtick */
+.highlight pre .sc, pre.code .sc { color: #BA2121 } /* Literal.String.Char */
+.highlight pre .sd, pre.code .sd { color: #BA2121; font-style: italic } /* Literal.String.Doc */
+.highlight pre .s, pre.code .s2 { color: #BA2121 } /* Literal.String.Double */
+.highlight pre .se, pre.code .se { color: #BB6622; font-weight: bold } /* Literal.String.Escape */
+.highlight pre .sh, pre.code .sh { color: #BA2121 } /* Literal.String.Heredoc */
+.highlight pre .si, pre.code .si { color: #BB6688; font-weight: bold } /* Literal.String.Interpol */
+.highlight pre .sx, pre.code .sx { color: #008000 } /* Literal.String.Other */
+.highlight pre .sr, pre.code .sr { color: #BB6688 } /* Literal.String.Regex */
+.highlight pre .s, pre.code .s1 { color: #BA2121 } /* Literal.String.Single */
+.highlight pre .ss, pre.code .ss { color: #19177C } /* Literal.String.Symbol */
+.highlight pre .bp, pre.code .bp { color: #008000 } /* Name.Builtin.Pseudo */
+.highlight pre .vc, pre.code .vc { color: #19177C } /* Name.Variable.Class */
+.highlight pre .vg, pre.code .vg { color: #19177C } /* Name.Variable.Global */
+.highlight pre .vi, pre.code .vi { color: #19177C } /* Name.Variable.Instance */
+.highlight pre .il, pre.code .il { color: #666666 } /* Literal.Number.Integer.Long */

--- a/pelican-bootstrap3/static/css/pygments/emacs.css
+++ b/pelican-bootstrap3/static/css/pygments/emacs.css
@@ -1,63 +1,63 @@
-.highlight pre .hll { background-color: #ffffcc }
-.highlight pre  { background: #f8f8f8; }
-.highlight pre .c { color: #008800; font-style: italic } /* Comment */
-.highlight pre .err { border: 1px solid #FF0000 } /* Error */
-.highlight pre .k { color: #AA22FF; font-weight: bold } /* Keyword */
-.highlight pre .o { color: #666666 } /* Operator */
-.highlight pre .cm { color: #008800; font-style: italic } /* Comment.Multiline */
-.highlight pre .cp { color: #008800 } /* Comment.Preproc */
-.highlight pre .c1 { color: #008800; font-style: italic } /* Comment.Single */
-.highlight pre .cs { color: #008800; font-weight: bold } /* Comment.Special */
-.highlight pre .gd { color: #A00000 } /* Generic.Deleted */
-.highlight pre .ge { font-style: italic } /* Generic.Emph */
-.highlight pre .gr { color: #FF0000 } /* Generic.Error */
-.highlight pre .gh { color: #000080; font-weight: bold } /* Generic.Heading */
-.highlight pre .gi { color: #00A000 } /* Generic.Inserted */
-.highlight pre .go { color: #888888 } /* Generic.Output */
-.highlight pre .gp { color: #000080; font-weight: bold } /* Generic.Prompt */
-.highlight pre .gs { font-weight: bold } /* Generic.Strong */
-.highlight pre .gu { color: #800080; font-weight: bold } /* Generic.Subheading */
-.highlight pre .gt { color: #0044DD } /* Generic.Traceback */
-.highlight pre .kc { color: #AA22FF; font-weight: bold } /* Keyword.Constant */
-.highlight pre .kd { color: #AA22FF; font-weight: bold } /* Keyword.Declaration */
-.highlight pre .kn { color: #AA22FF; font-weight: bold } /* Keyword.Namespace */
-.highlight pre .kp { color: #AA22FF } /* Keyword.Pseudo */
-.highlight pre .kr { color: #AA22FF; font-weight: bold } /* Keyword.Reserved */
-.highlight pre .kt { color: #00BB00; font-weight: bold } /* Keyword.Type */
-.highlight pre .m { color: #666666 } /* Literal.Number */
-.highlight pre .s { color: #BB4444 } /* Literal.String */
-.highlight pre .na { color: #BB4444 } /* Name.Attribute */
-.highlight pre .nb { color: #AA22FF } /* Name.Builtin */
-.highlight pre .nc { color: #0000FF } /* Name.Class */
-.highlight pre .no { color: #880000 } /* Name.Constant */
-.highlight pre .nd { color: #AA22FF } /* Name.Decorator */
-.highlight pre .ni { color: #999999; font-weight: bold } /* Name.Entity */
-.highlight pre .ne { color: #D2413A; font-weight: bold } /* Name.Exception */
-.highlight pre .nf { color: #00A000 } /* Name.Function */
-.highlight pre .nl { color: #A0A000 } /* Name.Label */
-.highlight pre .nn { color: #0000FF; font-weight: bold } /* Name.Namespace */
-.highlight pre .nt { color: #008000; font-weight: bold } /* Name.Tag */
-.highlight pre .nv { color: #B8860B } /* Name.Variable */
-.highlight pre .ow { color: #AA22FF; font-weight: bold } /* Operator.Word */
-.highlight pre .w { color: #bbbbbb } /* Text.Whitespace */
-.highlight pre .mb { color: #666666 } /* Literal.Number.Bin */
-.highlight pre .mf { color: #666666 } /* Literal.Number.Float */
-.highlight pre .mh { color: #666666 } /* Literal.Number.Hex */
-.highlight pre .mi { color: #666666 } /* Literal.Number.Integer */
-.highlight pre .mo { color: #666666 } /* Literal.Number.Oct */
-.highlight pre .sb { color: #BB4444 } /* Literal.String.Backtick */
-.highlight pre .sc { color: #BB4444 } /* Literal.String.Char */
-.highlight pre .sd { color: #BB4444; font-style: italic } /* Literal.String.Doc */
-.highlight pre .s2 { color: #BB4444 } /* Literal.String.Double */
-.highlight pre .se { color: #BB6622; font-weight: bold } /* Literal.String.Escape */
-.highlight pre .sh { color: #BB4444 } /* Literal.String.Heredoc */
-.highlight pre .si { color: #BB6688; font-weight: bold } /* Literal.String.Interpol */
-.highlight pre .sx { color: #008000 } /* Literal.String.Other */
-.highlight pre .sr { color: #BB6688 } /* Literal.String.Regex */
-.highlight pre .s1 { color: #BB4444 } /* Literal.String.Single */
-.highlight pre .ss { color: #B8860B } /* Literal.String.Symbol */
-.highlight pre .bp { color: #AA22FF } /* Name.Builtin.Pseudo */
-.highlight pre .vc { color: #B8860B } /* Name.Variable.Class */
-.highlight pre .vg { color: #B8860B } /* Name.Variable.Global */
-.highlight pre .vi { color: #B8860B } /* Name.Variable.Instance */
-.highlight pre .il { color: #666666 } /* Literal.Number.Integer.Long */
+.highlight pre .hll, pre.code .hll { background-color: #ffffcc }
+.highlight pre, pre.code { background: #f8f8f8; }
+.highlight pre .c, pre.code .c { color: #008800; font-style: italic } /* Comment */
+.highlight pre .err, pre.code .err { border: 1px solid #FF0000 } /* Error */
+.highlight pre .k, pre.code .k { color: #AA22FF; font-weight: bold } /* Keyword */
+.highlight pre .o, pre.code .o { color: #666666 } /* Operator */
+.highlight pre .cm, pre.code .cm { color: #008800; font-style: italic } /* Comment.Multiline */
+.highlight pre .cp, pre.code .cp { color: #008800 } /* Comment.Preproc */
+.highlight pre .c, pre.code .c1 { color: #008800; font-style: italic } /* Comment.Single */
+.highlight pre .cs, pre.code .cs { color: #008800; font-weight: bold } /* Comment.Special */
+.highlight pre .gd, pre.code .gd { color: #A00000 } /* Generic.Deleted */
+.highlight pre .ge, pre.code .ge { font-style: italic } /* Generic.Emph */
+.highlight pre .gr, pre.code .gr { color: #FF0000 } /* Generic.Error */
+.highlight pre .gh, pre.code .gh { color: #000080; font-weight: bold } /* Generic.Heading */
+.highlight pre .gi, pre.code .gi { color: #00A000 } /* Generic.Inserted */
+.highlight pre .go, pre.code .go { color: #888888 } /* Generic.Output */
+.highlight pre .gp, pre.code .gp { color: #000080; font-weight: bold } /* Generic.Prompt */
+.highlight pre .gs, pre.code .gs { font-weight: bold } /* Generic.Strong */
+.highlight pre .gu, pre.code .gu { color: #800080; font-weight: bold } /* Generic.Subheading */
+.highlight pre .gt, pre.code .gt { color: #0044DD } /* Generic.Traceback */
+.highlight pre .kc, pre.code .kc { color: #AA22FF; font-weight: bold } /* Keyword.Constant */
+.highlight pre .kd, pre.code .kd { color: #AA22FF; font-weight: bold } /* Keyword.Declaration */
+.highlight pre .kn, pre.code .kn { color: #AA22FF; font-weight: bold } /* Keyword.Namespace */
+.highlight pre .kp, pre.code .kp { color: #AA22FF } /* Keyword.Pseudo */
+.highlight pre .kr, pre.code .kr { color: #AA22FF; font-weight: bold } /* Keyword.Reserved */
+.highlight pre .kt, pre.code .kt { color: #00BB00; font-weight: bold } /* Keyword.Type */
+.highlight pre .m, pre.code .m { color: #666666 } /* Literal.Number */
+.highlight pre .s, pre.code .s { color: #BB4444 } /* Literal.String */
+.highlight pre .na, pre.code .na { color: #BB4444 } /* Name.Attribute */
+.highlight pre .nb, pre.code .nb { color: #AA22FF } /* Name.Builtin */
+.highlight pre .nc, pre.code .nc { color: #0000FF } /* Name.Class */
+.highlight pre .no, pre.code .no { color: #880000 } /* Name.Constant */
+.highlight pre .nd, pre.code .nd { color: #AA22FF } /* Name.Decorator */
+.highlight pre .ni, pre.code .ni { color: #999999; font-weight: bold } /* Name.Entity */
+.highlight pre .ne, pre.code .ne { color: #D2413A; font-weight: bold } /* Name.Exception */
+.highlight pre .nf, pre.code .nf { color: #00A000 } /* Name.Function */
+.highlight pre .nl, pre.code .nl { color: #A0A000 } /* Name.Label */
+.highlight pre .nn, pre.code .nn { color: #0000FF; font-weight: bold } /* Name.Namespace */
+.highlight pre .nt, pre.code .nt { color: #008000; font-weight: bold } /* Name.Tag */
+.highlight pre .nv, pre.code .nv { color: #B8860B } /* Name.Variable */
+.highlight pre .ow, pre.code .ow { color: #AA22FF; font-weight: bold } /* Operator.Word */
+.highlight pre .w, pre.code .w { color: #bbbbbb } /* Text.Whitespace */
+.highlight pre .mb, pre.code .mb { color: #666666 } /* Literal.Number.Bin */
+.highlight pre .mf, pre.code .mf { color: #666666 } /* Literal.Number.Float */
+.highlight pre .mh, pre.code .mh { color: #666666 } /* Literal.Number.Hex */
+.highlight pre .mi, pre.code .mi { color: #666666 } /* Literal.Number.Integer */
+.highlight pre .mo, pre.code .mo { color: #666666 } /* Literal.Number.Oct */
+.highlight pre .sb, pre.code .sb { color: #BB4444 } /* Literal.String.Backtick */
+.highlight pre .sc, pre.code .sc { color: #BB4444 } /* Literal.String.Char */
+.highlight pre .sd, pre.code .sd { color: #BB4444; font-style: italic } /* Literal.String.Doc */
+.highlight pre .s, pre.code .s2 { color: #BB4444 } /* Literal.String.Double */
+.highlight pre .se, pre.code .se { color: #BB6622; font-weight: bold } /* Literal.String.Escape */
+.highlight pre .sh, pre.code .sh { color: #BB4444 } /* Literal.String.Heredoc */
+.highlight pre .si, pre.code .si { color: #BB6688; font-weight: bold } /* Literal.String.Interpol */
+.highlight pre .sx, pre.code .sx { color: #008000 } /* Literal.String.Other */
+.highlight pre .sr, pre.code .sr { color: #BB6688 } /* Literal.String.Regex */
+.highlight pre .s, pre.code .s1 { color: #BB4444 } /* Literal.String.Single */
+.highlight pre .ss, pre.code .ss { color: #B8860B } /* Literal.String.Symbol */
+.highlight pre .bp, pre.code .bp { color: #AA22FF } /* Name.Builtin.Pseudo */
+.highlight pre .vc, pre.code .vc { color: #B8860B } /* Name.Variable.Class */
+.highlight pre .vg, pre.code .vg { color: #B8860B } /* Name.Variable.Global */
+.highlight pre .vi, pre.code .vi { color: #B8860B } /* Name.Variable.Instance */
+.highlight pre .il, pre.code .il { color: #666666 } /* Literal.Number.Integer.Long */

--- a/pelican-bootstrap3/static/css/pygments/friendly.css
+++ b/pelican-bootstrap3/static/css/pygments/friendly.css
@@ -1,63 +1,63 @@
-.highlight pre .hll { background-color: #ffffcc }
-.highlight pre  { background: #f0f0f0; }
-.highlight pre .c { color: #60a0b0; font-style: italic } /* Comment */
-.highlight pre .err { border: 1px solid #FF0000 } /* Error */
-.highlight pre .k { color: #007020; font-weight: bold } /* Keyword */
-.highlight pre .o { color: #666666 } /* Operator */
-.highlight pre .cm { color: #60a0b0; font-style: italic } /* Comment.Multiline */
-.highlight pre .cp { color: #007020 } /* Comment.Preproc */
-.highlight pre .c1 { color: #60a0b0; font-style: italic } /* Comment.Single */
-.highlight pre .cs { color: #60a0b0; background-color: #fff0f0 } /* Comment.Special */
-.highlight pre .gd { color: #A00000 } /* Generic.Deleted */
-.highlight pre .ge { font-style: italic } /* Generic.Emph */
-.highlight pre .gr { color: #FF0000 } /* Generic.Error */
-.highlight pre .gh { color: #000080; font-weight: bold } /* Generic.Heading */
-.highlight pre .gi { color: #00A000 } /* Generic.Inserted */
-.highlight pre .go { color: #888888 } /* Generic.Output */
-.highlight pre .gp { color: #c65d09; font-weight: bold } /* Generic.Prompt */
-.highlight pre .gs { font-weight: bold } /* Generic.Strong */
-.highlight pre .gu { color: #800080; font-weight: bold } /* Generic.Subheading */
-.highlight pre .gt { color: #0044DD } /* Generic.Traceback */
-.highlight pre .kc { color: #007020; font-weight: bold } /* Keyword.Constant */
-.highlight pre .kd { color: #007020; font-weight: bold } /* Keyword.Declaration */
-.highlight pre .kn { color: #007020; font-weight: bold } /* Keyword.Namespace */
-.highlight pre .kp { color: #007020 } /* Keyword.Pseudo */
-.highlight pre .kr { color: #007020; font-weight: bold } /* Keyword.Reserved */
-.highlight pre .kt { color: #902000 } /* Keyword.Type */
-.highlight pre .m { color: #40a070 } /* Literal.Number */
-.highlight pre .s { color: #4070a0 } /* Literal.String */
-.highlight pre .na { color: #4070a0 } /* Name.Attribute */
-.highlight pre .nb { color: #007020 } /* Name.Builtin */
-.highlight pre .nc { color: #0e84b5; font-weight: bold } /* Name.Class */
-.highlight pre .no { color: #60add5 } /* Name.Constant */
-.highlight pre .nd { color: #555555; font-weight: bold } /* Name.Decorator */
-.highlight pre .ni { color: #d55537; font-weight: bold } /* Name.Entity */
-.highlight pre .ne { color: #007020 } /* Name.Exception */
-.highlight pre .nf { color: #06287e } /* Name.Function */
-.highlight pre .nl { color: #002070; font-weight: bold } /* Name.Label */
-.highlight pre .nn { color: #0e84b5; font-weight: bold } /* Name.Namespace */
-.highlight pre .nt { color: #062873; font-weight: bold } /* Name.Tag */
-.highlight pre .nv { color: #bb60d5 } /* Name.Variable */
-.highlight pre .ow { color: #007020; font-weight: bold } /* Operator.Word */
-.highlight pre .w { color: #bbbbbb } /* Text.Whitespace */
-.highlight pre .mb { color: #40a070 } /* Literal.Number.Bin */
-.highlight pre .mf { color: #40a070 } /* Literal.Number.Float */
-.highlight pre .mh { color: #40a070 } /* Literal.Number.Hex */
-.highlight pre .mi { color: #40a070 } /* Literal.Number.Integer */
-.highlight pre .mo { color: #40a070 } /* Literal.Number.Oct */
-.highlight pre .sb { color: #4070a0 } /* Literal.String.Backtick */
-.highlight pre .sc { color: #4070a0 } /* Literal.String.Char */
-.highlight pre .sd { color: #4070a0; font-style: italic } /* Literal.String.Doc */
-.highlight pre .s2 { color: #4070a0 } /* Literal.String.Double */
-.highlight pre .se { color: #4070a0; font-weight: bold } /* Literal.String.Escape */
-.highlight pre .sh { color: #4070a0 } /* Literal.String.Heredoc */
-.highlight pre .si { color: #70a0d0; font-style: italic } /* Literal.String.Interpol */
-.highlight pre .sx { color: #c65d09 } /* Literal.String.Other */
-.highlight pre .sr { color: #235388 } /* Literal.String.Regex */
-.highlight pre .s1 { color: #4070a0 } /* Literal.String.Single */
-.highlight pre .ss { color: #517918 } /* Literal.String.Symbol */
-.highlight pre .bp { color: #007020 } /* Name.Builtin.Pseudo */
-.highlight pre .vc { color: #bb60d5 } /* Name.Variable.Class */
-.highlight pre .vg { color: #bb60d5 } /* Name.Variable.Global */
-.highlight pre .vi { color: #bb60d5 } /* Name.Variable.Instance */
-.highlight pre .il { color: #40a070 } /* Literal.Number.Integer.Long */
+.highlight pre .hll, pre.code .hll { background-color: #ffffcc }
+.highlight pre, pre.code { background: #f0f0f0; }
+.highlight pre .c, pre.code .c { color: #60a0b0; font-style: italic } /* Comment */
+.highlight pre .err, pre.code .err { border: 1px solid #FF0000 } /* Error */
+.highlight pre .k, pre.code .k { color: #007020; font-weight: bold } /* Keyword */
+.highlight pre .o, pre.code .o { color: #666666 } /* Operator */
+.highlight pre .cm, pre.code .cm { color: #60a0b0; font-style: italic } /* Comment.Multiline */
+.highlight pre .cp, pre.code .cp { color: #007020 } /* Comment.Preproc */
+.highlight pre .c, pre.code .c1 { color: #60a0b0; font-style: italic } /* Comment.Single */
+.highlight pre .cs, pre.code .cs { color: #60a0b0; background-color: #fff0f0 } /* Comment.Special */
+.highlight pre .gd, pre.code .gd { color: #A00000 } /* Generic.Deleted */
+.highlight pre .ge, pre.code .ge { font-style: italic } /* Generic.Emph */
+.highlight pre .gr, pre.code .gr { color: #FF0000 } /* Generic.Error */
+.highlight pre .gh, pre.code .gh { color: #000080; font-weight: bold } /* Generic.Heading */
+.highlight pre .gi, pre.code .gi { color: #00A000 } /* Generic.Inserted */
+.highlight pre .go, pre.code .go { color: #888888 } /* Generic.Output */
+.highlight pre .gp, pre.code .gp { color: #c65d09; font-weight: bold } /* Generic.Prompt */
+.highlight pre .gs, pre.code .gs { font-weight: bold } /* Generic.Strong */
+.highlight pre .gu, pre.code .gu { color: #800080; font-weight: bold } /* Generic.Subheading */
+.highlight pre .gt, pre.code .gt { color: #0044DD } /* Generic.Traceback */
+.highlight pre .kc, pre.code .kc { color: #007020; font-weight: bold } /* Keyword.Constant */
+.highlight pre .kd, pre.code .kd { color: #007020; font-weight: bold } /* Keyword.Declaration */
+.highlight pre .kn, pre.code .kn { color: #007020; font-weight: bold } /* Keyword.Namespace */
+.highlight pre .kp, pre.code .kp { color: #007020 } /* Keyword.Pseudo */
+.highlight pre .kr, pre.code .kr { color: #007020; font-weight: bold } /* Keyword.Reserved */
+.highlight pre .kt, pre.code .kt { color: #902000 } /* Keyword.Type */
+.highlight pre .m, pre.code .m { color: #40a070 } /* Literal.Number */
+.highlight pre .s, pre.code .s { color: #4070a0 } /* Literal.String */
+.highlight pre .na, pre.code .na { color: #4070a0 } /* Name.Attribute */
+.highlight pre .nb, pre.code .nb { color: #007020 } /* Name.Builtin */
+.highlight pre .nc, pre.code .nc { color: #0e84b5; font-weight: bold } /* Name.Class */
+.highlight pre .no, pre.code .no { color: #60add5 } /* Name.Constant */
+.highlight pre .nd, pre.code .nd { color: #555555; font-weight: bold } /* Name.Decorator */
+.highlight pre .ni, pre.code .ni { color: #d55537; font-weight: bold } /* Name.Entity */
+.highlight pre .ne, pre.code .ne { color: #007020 } /* Name.Exception */
+.highlight pre .nf, pre.code .nf { color: #06287e } /* Name.Function */
+.highlight pre .nl, pre.code .nl { color: #002070; font-weight: bold } /* Name.Label */
+.highlight pre .nn, pre.code .nn { color: #0e84b5; font-weight: bold } /* Name.Namespace */
+.highlight pre .nt, pre.code .nt { color: #062873; font-weight: bold } /* Name.Tag */
+.highlight pre .nv, pre.code .nv { color: #bb60d5 } /* Name.Variable */
+.highlight pre .ow, pre.code .ow { color: #007020; font-weight: bold } /* Operator.Word */
+.highlight pre .w, pre.code .w { color: #bbbbbb } /* Text.Whitespace */
+.highlight pre .mb, pre.code .mb { color: #40a070 } /* Literal.Number.Bin */
+.highlight pre .mf, pre.code .mf { color: #40a070 } /* Literal.Number.Float */
+.highlight pre .mh, pre.code .mh { color: #40a070 } /* Literal.Number.Hex */
+.highlight pre .mi, pre.code .mi { color: #40a070 } /* Literal.Number.Integer */
+.highlight pre .mo, pre.code .mo { color: #40a070 } /* Literal.Number.Oct */
+.highlight pre .sb, pre.code .sb { color: #4070a0 } /* Literal.String.Backtick */
+.highlight pre .sc, pre.code .sc { color: #4070a0 } /* Literal.String.Char */
+.highlight pre .sd, pre.code .sd { color: #4070a0; font-style: italic } /* Literal.String.Doc */
+.highlight pre .s, pre.code .s2 { color: #4070a0 } /* Literal.String.Double */
+.highlight pre .se, pre.code .se { color: #4070a0; font-weight: bold } /* Literal.String.Escape */
+.highlight pre .sh, pre.code .sh { color: #4070a0 } /* Literal.String.Heredoc */
+.highlight pre .si, pre.code .si { color: #70a0d0; font-style: italic } /* Literal.String.Interpol */
+.highlight pre .sx, pre.code .sx { color: #c65d09 } /* Literal.String.Other */
+.highlight pre .sr, pre.code .sr { color: #235388 } /* Literal.String.Regex */
+.highlight pre .s, pre.code .s1 { color: #4070a0 } /* Literal.String.Single */
+.highlight pre .ss, pre.code .ss { color: #517918 } /* Literal.String.Symbol */
+.highlight pre .bp, pre.code .bp { color: #007020 } /* Name.Builtin.Pseudo */
+.highlight pre .vc, pre.code .vc { color: #bb60d5 } /* Name.Variable.Class */
+.highlight pre .vg, pre.code .vg { color: #bb60d5 } /* Name.Variable.Global */
+.highlight pre .vi, pre.code .vi { color: #bb60d5 } /* Name.Variable.Instance */
+.highlight pre .il, pre.code .il { color: #40a070 } /* Literal.Number.Integer.Long */

--- a/pelican-bootstrap3/static/css/pygments/fruity.css
+++ b/pelican-bootstrap3/static/css/pygments/fruity.css
@@ -1,72 +1,72 @@
-.highlight pre .hll { background-color: #333333 }
-.highlight pre  { background: #111111; color: #ffffff }
-.highlight pre .c { color: #008800; font-style: italic; background-color: #0f140f } /* Comment */
-.highlight pre .err { color: #ffffff } /* Error */
-.highlight pre .esc { color: #ffffff } /* Escape */
-.highlight pre .g { color: #ffffff } /* Generic */
-.highlight pre .k { color: #fb660a; font-weight: bold } /* Keyword */
-.highlight pre .l { color: #ffffff } /* Literal */
-.highlight pre .n { color: #ffffff } /* Name */
-.highlight pre .o { color: #ffffff } /* Operator */
-.highlight pre .x { color: #ffffff } /* Other */
-.highlight pre .p { color: #ffffff } /* Punctuation */
-.highlight pre .cm { color: #008800; font-style: italic; background-color: #0f140f } /* Comment.Multiline */
-.highlight pre .cp { color: #ff0007; font-weight: bold; font-style: italic; background-color: #0f140f } /* Comment.Preproc */
-.highlight pre .c1 { color: #008800; font-style: italic; background-color: #0f140f } /* Comment.Single */
-.highlight pre .cs { color: #008800; font-style: italic; background-color: #0f140f } /* Comment.Special */
-.highlight pre .gd { color: #ffffff } /* Generic.Deleted */
-.highlight pre .ge { color: #ffffff } /* Generic.Emph */
-.highlight pre .gr { color: #ffffff } /* Generic.Error */
-.highlight pre .gh { color: #ffffff; font-weight: bold } /* Generic.Heading */
-.highlight pre .gi { color: #ffffff } /* Generic.Inserted */
-.highlight pre .go { color: #444444; background-color: #222222 } /* Generic.Output */
-.highlight pre .gp { color: #ffffff } /* Generic.Prompt */
-.highlight pre .gs { color: #ffffff } /* Generic.Strong */
-.highlight pre .gu { color: #ffffff; font-weight: bold } /* Generic.Subheading */
-.highlight pre .gt { color: #ffffff } /* Generic.Traceback */
-.highlight pre .kc { color: #fb660a; font-weight: bold } /* Keyword.Constant */
-.highlight pre .kd { color: #fb660a; font-weight: bold } /* Keyword.Declaration */
-.highlight pre .kn { color: #fb660a; font-weight: bold } /* Keyword.Namespace */
-.highlight pre .kp { color: #fb660a } /* Keyword.Pseudo */
-.highlight pre .kr { color: #fb660a; font-weight: bold } /* Keyword.Reserved */
-.highlight pre .kt { color: #cdcaa9; font-weight: bold } /* Keyword.Type */
-.highlight pre .ld { color: #ffffff } /* Literal.Date */
-.highlight pre .m { color: #0086f7; font-weight: bold } /* Literal.Number */
-.highlight pre .s { color: #0086d2 } /* Literal.String */
-.highlight pre .na { color: #ff0086; font-weight: bold } /* Name.Attribute */
-.highlight pre .nb { color: #ffffff } /* Name.Builtin */
-.highlight pre .nc { color: #ffffff } /* Name.Class */
-.highlight pre .no { color: #0086d2 } /* Name.Constant */
-.highlight pre .nd { color: #ffffff } /* Name.Decorator */
-.highlight pre .ni { color: #ffffff } /* Name.Entity */
-.highlight pre .ne { color: #ffffff } /* Name.Exception */
-.highlight pre .nf { color: #ff0086; font-weight: bold } /* Name.Function */
-.highlight pre .nl { color: #ffffff } /* Name.Label */
-.highlight pre .nn { color: #ffffff } /* Name.Namespace */
-.highlight pre .nx { color: #ffffff } /* Name.Other */
-.highlight pre .py { color: #ffffff } /* Name.Property */
-.highlight pre .nt { color: #fb660a; font-weight: bold } /* Name.Tag */
-.highlight pre .nv { color: #fb660a } /* Name.Variable */
-.highlight pre .ow { color: #ffffff } /* Operator.Word */
-.highlight pre .w { color: #888888 } /* Text.Whitespace */
-.highlight pre .mb { color: #0086f7; font-weight: bold } /* Literal.Number.Bin */
-.highlight pre .mf { color: #0086f7; font-weight: bold } /* Literal.Number.Float */
-.highlight pre .mh { color: #0086f7; font-weight: bold } /* Literal.Number.Hex */
-.highlight pre .mi { color: #0086f7; font-weight: bold } /* Literal.Number.Integer */
-.highlight pre .mo { color: #0086f7; font-weight: bold } /* Literal.Number.Oct */
-.highlight pre .sb { color: #0086d2 } /* Literal.String.Backtick */
-.highlight pre .sc { color: #0086d2 } /* Literal.String.Char */
-.highlight pre .sd { color: #0086d2 } /* Literal.String.Doc */
-.highlight pre .s2 { color: #0086d2 } /* Literal.String.Double */
-.highlight pre .se { color: #0086d2 } /* Literal.String.Escape */
-.highlight pre .sh { color: #0086d2 } /* Literal.String.Heredoc */
-.highlight pre .si { color: #0086d2 } /* Literal.String.Interpol */
-.highlight pre .sx { color: #0086d2 } /* Literal.String.Other */
-.highlight pre .sr { color: #0086d2 } /* Literal.String.Regex */
-.highlight pre .s1 { color: #0086d2 } /* Literal.String.Single */
-.highlight pre .ss { color: #0086d2 } /* Literal.String.Symbol */
-.highlight pre .bp { color: #ffffff } /* Name.Builtin.Pseudo */
-.highlight pre .vc { color: #fb660a } /* Name.Variable.Class */
-.highlight pre .vg { color: #fb660a } /* Name.Variable.Global */
-.highlight pre .vi { color: #fb660a } /* Name.Variable.Instance */
-.highlight pre .il { color: #0086f7; font-weight: bold } /* Literal.Number.Integer.Long */
+.highlight pre .hll, pre.code .hll { background-color: #333333 }
+.highlight pre, pre.code  { background: #111111; color: #ffffff }
+.highlight pre .c, pre.code .c { color: #008800; font-style: italic; background-color: #0f140f } /* Comment */
+.highlight pre .err, pre.code .err { color: #ffffff } /* Error */
+.highlight pre .esc, pre.code .esc { color: #ffffff } /* Escape */
+.highlight pre .g, pre.code .g { color: #ffffff } /* Generic */
+.highlight pre .k, pre.code .k { color: #fb660a; font-weight: bold } /* Keyword */
+.highlight pre .l, pre.code .l { color: #ffffff } /* Literal */
+.highlight pre .n, pre.code .n { color: #ffffff } /* Name */
+.highlight pre .o, pre.code .o { color: #ffffff } /* Operator */
+.highlight pre .x, pre.code .x { color: #ffffff } /* Other */
+.highlight pre .p, pre.code .p { color: #ffffff } /* Punctuation */
+.highlight pre .cm, pre.code .cm { color: #008800; font-style: italic; background-color: #0f140f } /* Comment.Multiline */
+.highlight pre .cp, pre.code .cp { color: #ff0007; font-weight: bold; font-style: italic; background-color: #0f140f } /* Comment.Preproc */
+.highlight pre .c, pre.code .c1 { color: #008800; font-style: italic; background-color: #0f140f } /* Comment.Single */
+.highlight pre .cs, pre.code .cs { color: #008800; font-style: italic; background-color: #0f140f } /* Comment.Special */
+.highlight pre .gd, pre.code .gd { color: #ffffff } /* Generic.Deleted */
+.highlight pre .ge, pre.code .ge { color: #ffffff } /* Generic.Emph */
+.highlight pre .gr, pre.code .gr { color: #ffffff } /* Generic.Error */
+.highlight pre .gh, pre.code .gh { color: #ffffff; font-weight: bold } /* Generic.Heading */
+.highlight pre .gi, pre.code .gi { color: #ffffff } /* Generic.Inserted */
+.highlight pre .go, pre.code .go { color: #444444; background-color: #222222 } /* Generic.Output */
+.highlight pre .gp, pre.code .gp { color: #ffffff } /* Generic.Prompt */
+.highlight pre .gs, pre.code .gs { color: #ffffff } /* Generic.Strong */
+.highlight pre .gu, pre.code .gu { color: #ffffff; font-weight: bold } /* Generic.Subheading */
+.highlight pre .gt, pre.code .gt { color: #ffffff } /* Generic.Traceback */
+.highlight pre .kc, pre.code .kc { color: #fb660a; font-weight: bold } /* Keyword.Constant */
+.highlight pre .kd, pre.code .kd { color: #fb660a; font-weight: bold } /* Keyword.Declaration */
+.highlight pre .kn, pre.code .kn { color: #fb660a; font-weight: bold } /* Keyword.Namespace */
+.highlight pre .kp, pre.code .kp { color: #fb660a } /* Keyword.Pseudo */
+.highlight pre .kr, pre.code .kr { color: #fb660a; font-weight: bold } /* Keyword.Reserved */
+.highlight pre .kt, pre.code .kt { color: #cdcaa9; font-weight: bold } /* Keyword.Type */
+.highlight pre .ld, pre.code .ld { color: #ffffff } /* Literal.Date */
+.highlight pre .m, pre.code .m { color: #0086f7; font-weight: bold } /* Literal.Number */
+.highlight pre .s, pre.code .s { color: #0086d2 } /* Literal.String */
+.highlight pre .na, pre.code .na { color: #ff0086; font-weight: bold } /* Name.Attribute */
+.highlight pre .nb, pre.code .nb { color: #ffffff } /* Name.Builtin */
+.highlight pre .nc, pre.code .nc { color: #ffffff } /* Name.Class */
+.highlight pre .no, pre.code .no { color: #0086d2 } /* Name.Constant */
+.highlight pre .nd, pre.code .nd { color: #ffffff } /* Name.Decorator */
+.highlight pre .ni, pre.code .ni { color: #ffffff } /* Name.Entity */
+.highlight pre .ne, pre.code .ne { color: #ffffff } /* Name.Exception */
+.highlight pre .nf, pre.code .nf { color: #ff0086; font-weight: bold } /* Name.Function */
+.highlight pre .nl, pre.code .nl { color: #ffffff } /* Name.Label */
+.highlight pre .nn, pre.code .nn { color: #ffffff } /* Name.Namespace */
+.highlight pre .nx, pre.code .nx { color: #ffffff } /* Name.Other */
+.highlight pre .py, pre.code .py { color: #ffffff } /* Name.Property */
+.highlight pre .nt, pre.code .nt { color: #fb660a; font-weight: bold } /* Name.Tag */
+.highlight pre .nv, pre.code .nv { color: #fb660a } /* Name.Variable */
+.highlight pre .ow, pre.code .ow { color: #ffffff } /* Operator.Word */
+.highlight pre .w, pre.code .w { color: #888888 } /* Text.Whitespace */
+.highlight pre .mb, pre.code .mb { color: #0086f7; font-weight: bold } /* Literal.Number.Bin */
+.highlight pre .mf, pre.code .mf { color: #0086f7; font-weight: bold } /* Literal.Number.Float */
+.highlight pre .mh, pre.code .mh { color: #0086f7; font-weight: bold } /* Literal.Number.Hex */
+.highlight pre .mi, pre.code .mi { color: #0086f7; font-weight: bold } /* Literal.Number.Integer */
+.highlight pre .mo, pre.code .mo { color: #0086f7; font-weight: bold } /* Literal.Number.Oct */
+.highlight pre .sb, pre.code .sb { color: #0086d2 } /* Literal.String.Backtick */
+.highlight pre .sc, pre.code .sc { color: #0086d2 } /* Literal.String.Char */
+.highlight pre .sd, pre.code .sd { color: #0086d2 } /* Literal.String.Doc */
+.highlight pre .s, pre.code .s2 { color: #0086d2 } /* Literal.String.Double */
+.highlight pre .se, pre.code .se { color: #0086d2 } /* Literal.String.Escape */
+.highlight pre .sh, pre.code .sh { color: #0086d2 } /* Literal.String.Heredoc */
+.highlight pre .si, pre.code .si { color: #0086d2 } /* Literal.String.Interpol */
+.highlight pre .sx, pre.code .sx { color: #0086d2 } /* Literal.String.Other */
+.highlight pre .sr, pre.code .sr { color: #0086d2 } /* Literal.String.Regex */
+.highlight pre .s, pre.code .s1 { color: #0086d2 } /* Literal.String.Single */
+.highlight pre .ss, pre.code .ss { color: #0086d2 } /* Literal.String.Symbol */
+.highlight pre .bp, pre.code .bp { color: #ffffff } /* Name.Builtin.Pseudo */
+.highlight pre .vc, pre.code .vc { color: #fb660a } /* Name.Variable.Class */
+.highlight pre .vg, pre.code .vg { color: #fb660a } /* Name.Variable.Global */
+.highlight pre .vi, pre.code .vi { color: #fb660a } /* Name.Variable.Instance */
+.highlight pre .il, pre.code .il { color: #0086f7; font-weight: bold } /* Literal.Number.Integer.Long */

--- a/pelican-bootstrap3/static/css/pygments/igor.css
+++ b/pelican-bootstrap3/static/css/pygments/igor.css
@@ -1,29 +1,29 @@
-.highlight pre .hll { background-color: #ffffcc }
-.highlight pre  { background: #ffffff; }
-.highlight pre .c { color: #FF0000; font-style: italic } /* Comment */
-.highlight pre .k { color: #0000FF } /* Keyword */
-.highlight pre .cm { color: #FF0000; font-style: italic } /* Comment.Multiline */
-.highlight pre .cp { color: #FF0000; font-style: italic } /* Comment.Preproc */
-.highlight pre .c1 { color: #FF0000; font-style: italic } /* Comment.Single */
-.highlight pre .cs { color: #FF0000; font-style: italic } /* Comment.Special */
-.highlight pre .kc { color: #0000FF } /* Keyword.Constant */
-.highlight pre .kd { color: #0000FF } /* Keyword.Declaration */
-.highlight pre .kn { color: #0000FF } /* Keyword.Namespace */
-.highlight pre .kp { color: #0000FF } /* Keyword.Pseudo */
-.highlight pre .kr { color: #0000FF } /* Keyword.Reserved */
-.highlight pre .kt { color: #0000FF } /* Keyword.Type */
-.highlight pre .s { color: #009C00 } /* Literal.String */
-.highlight pre .nc { color: #007575 } /* Name.Class */
-.highlight pre .nd { color: #CC00A3 } /* Name.Decorator */
-.highlight pre .nf { color: #C34E00 } /* Name.Function */
-.highlight pre .sb { color: #009C00 } /* Literal.String.Backtick */
-.highlight pre .sc { color: #009C00 } /* Literal.String.Char */
-.highlight pre .sd { color: #009C00 } /* Literal.String.Doc */
-.highlight pre .s2 { color: #009C00 } /* Literal.String.Double */
-.highlight pre .se { color: #009C00 } /* Literal.String.Escape */
-.highlight pre .sh { color: #009C00 } /* Literal.String.Heredoc */
-.highlight pre .si { color: #009C00 } /* Literal.String.Interpol */
-.highlight pre .sx { color: #009C00 } /* Literal.String.Other */
-.highlight pre .sr { color: #009C00 } /* Literal.String.Regex */
-.highlight pre .s1 { color: #009C00 } /* Literal.String.Single */
-.highlight pre .ss { color: #009C00 } /* Literal.String.Symbol */
+.highlight pre .hll, pre.code .hll { background-color: #ffffcc }
+.highlight pre, pre.code { background: #ffffff; }
+.highlight pre .c, pre.code .c { color: #FF0000; font-style: italic } /* Comment */
+.highlight pre .k, pre.code .k { color: #0000FF } /* Keyword */
+.highlight pre .cm, pre.code .cm { color: #FF0000; font-style: italic } /* Comment.Multiline */
+.highlight pre .cp, pre.code .cp { color: #FF0000; font-style: italic } /* Comment.Preproc */
+.highlight pre .c, pre.code .c1 { color: #FF0000; font-style: italic } /* Comment.Single */
+.highlight pre .cs, pre.code .cs { color: #FF0000; font-style: italic } /* Comment.Special */
+.highlight pre .kc, pre.code .kc { color: #0000FF } /* Keyword.Constant */
+.highlight pre .kd, pre.code .kd { color: #0000FF } /* Keyword.Declaration */
+.highlight pre .kn, pre.code .kn { color: #0000FF } /* Keyword.Namespace */
+.highlight pre .kp, pre.code .kp { color: #0000FF } /* Keyword.Pseudo */
+.highlight pre .kr, pre.code .kr { color: #0000FF } /* Keyword.Reserved */
+.highlight pre .kt, pre.code .kt { color: #0000FF } /* Keyword.Type */
+.highlight pre .s, pre.code .s { color: #009C00 } /* Literal.String */
+.highlight pre .nc, pre.code .nc { color: #007575 } /* Name.Class */
+.highlight pre .nd, pre.code .nd { color: #CC00A3 } /* Name.Decorator */
+.highlight pre .nf, pre.code .nf { color: #C34E00 } /* Name.Function */
+.highlight pre .sb, pre.code .sb { color: #009C00 } /* Literal.String.Backtick */
+.highlight pre .sc, pre.code .sc { color: #009C00 } /* Literal.String.Char */
+.highlight pre .sd, pre.code .sd { color: #009C00 } /* Literal.String.Doc */
+.highlight pre .s, pre.code .s2 { color: #009C00 } /* Literal.String.Double */
+.highlight pre .se, pre.code .se { color: #009C00 } /* Literal.String.Escape */
+.highlight pre .sh, pre.code .sh { color: #009C00 } /* Literal.String.Heredoc */
+.highlight pre .si, pre.code .si { color: #009C00 } /* Literal.String.Interpol */
+.highlight pre .sx, pre.code .sx { color: #009C00 } /* Literal.String.Other */
+.highlight pre .sr, pre.code .sr { color: #009C00 } /* Literal.String.Regex */
+.highlight pre .s, pre.code .s1 { color: #009C00 } /* Literal.String.Single */
+.highlight pre .ss, pre.code .ss { color: #009C00 } /* Literal.String.Symbol */

--- a/pelican-bootstrap3/static/css/pygments/manni.css
+++ b/pelican-bootstrap3/static/css/pygments/manni.css
@@ -1,63 +1,63 @@
-.highlight pre .hll { background-color: #ffffcc }
-.highlight pre  { background: #f0f3f3; }
-.highlight pre .c { color: #0099FF; font-style: italic } /* Comment */
-.highlight pre .err { color: #AA0000; background-color: #FFAAAA } /* Error */
-.highlight pre .k { color: #006699; font-weight: bold } /* Keyword */
-.highlight pre .o { color: #555555 } /* Operator */
-.highlight pre .cm { color: #0099FF; font-style: italic } /* Comment.Multiline */
-.highlight pre .cp { color: #009999 } /* Comment.Preproc */
-.highlight pre .c1 { color: #0099FF; font-style: italic } /* Comment.Single */
-.highlight pre .cs { color: #0099FF; font-weight: bold; font-style: italic } /* Comment.Special */
-.highlight pre .gd { background-color: #FFCCCC; border: 1px solid #CC0000 } /* Generic.Deleted */
-.highlight pre .ge { font-style: italic } /* Generic.Emph */
-.highlight pre .gr { color: #FF0000 } /* Generic.Error */
-.highlight pre .gh { color: #003300; font-weight: bold } /* Generic.Heading */
-.highlight pre .gi { background-color: #CCFFCC; border: 1px solid #00CC00 } /* Generic.Inserted */
-.highlight pre .go { color: #AAAAAA } /* Generic.Output */
-.highlight pre .gp { color: #000099; font-weight: bold } /* Generic.Prompt */
-.highlight pre .gs { font-weight: bold } /* Generic.Strong */
-.highlight pre .gu { color: #003300; font-weight: bold } /* Generic.Subheading */
-.highlight pre .gt { color: #99CC66 } /* Generic.Traceback */
-.highlight pre .kc { color: #006699; font-weight: bold } /* Keyword.Constant */
-.highlight pre .kd { color: #006699; font-weight: bold } /* Keyword.Declaration */
-.highlight pre .kn { color: #006699; font-weight: bold } /* Keyword.Namespace */
-.highlight pre .kp { color: #006699 } /* Keyword.Pseudo */
-.highlight pre .kr { color: #006699; font-weight: bold } /* Keyword.Reserved */
-.highlight pre .kt { color: #007788; font-weight: bold } /* Keyword.Type */
-.highlight pre .m { color: #FF6600 } /* Literal.Number */
-.highlight pre .s { color: #CC3300 } /* Literal.String */
-.highlight pre .na { color: #330099 } /* Name.Attribute */
-.highlight pre .nb { color: #336666 } /* Name.Builtin */
-.highlight pre .nc { color: #00AA88; font-weight: bold } /* Name.Class */
-.highlight pre .no { color: #336600 } /* Name.Constant */
-.highlight pre .nd { color: #9999FF } /* Name.Decorator */
-.highlight pre .ni { color: #999999; font-weight: bold } /* Name.Entity */
-.highlight pre .ne { color: #CC0000; font-weight: bold } /* Name.Exception */
-.highlight pre .nf { color: #CC00FF } /* Name.Function */
-.highlight pre .nl { color: #9999FF } /* Name.Label */
-.highlight pre .nn { color: #00CCFF; font-weight: bold } /* Name.Namespace */
-.highlight pre .nt { color: #330099; font-weight: bold } /* Name.Tag */
-.highlight pre .nv { color: #003333 } /* Name.Variable */
-.highlight pre .ow { color: #000000; font-weight: bold } /* Operator.Word */
-.highlight pre .w { color: #bbbbbb } /* Text.Whitespace */
-.highlight pre .mb { color: #FF6600 } /* Literal.Number.Bin */
-.highlight pre .mf { color: #FF6600 } /* Literal.Number.Float */
-.highlight pre .mh { color: #FF6600 } /* Literal.Number.Hex */
-.highlight pre .mi { color: #FF6600 } /* Literal.Number.Integer */
-.highlight pre .mo { color: #FF6600 } /* Literal.Number.Oct */
-.highlight pre .sb { color: #CC3300 } /* Literal.String.Backtick */
-.highlight pre .sc { color: #CC3300 } /* Literal.String.Char */
-.highlight pre .sd { color: #CC3300; font-style: italic } /* Literal.String.Doc */
-.highlight pre .s2 { color: #CC3300 } /* Literal.String.Double */
-.highlight pre .se { color: #CC3300; font-weight: bold } /* Literal.String.Escape */
-.highlight pre .sh { color: #CC3300 } /* Literal.String.Heredoc */
-.highlight pre .si { color: #AA0000 } /* Literal.String.Interpol */
-.highlight pre .sx { color: #CC3300 } /* Literal.String.Other */
-.highlight pre .sr { color: #33AAAA } /* Literal.String.Regex */
-.highlight pre .s1 { color: #CC3300 } /* Literal.String.Single */
-.highlight pre .ss { color: #FFCC33 } /* Literal.String.Symbol */
-.highlight pre .bp { color: #336666 } /* Name.Builtin.Pseudo */
-.highlight pre .vc { color: #003333 } /* Name.Variable.Class */
-.highlight pre .vg { color: #003333 } /* Name.Variable.Global */
-.highlight pre .vi { color: #003333 } /* Name.Variable.Instance */
-.highlight pre .il { color: #FF6600 } /* Literal.Number.Integer.Long */
+.highlight pre .hll, pre.code .hll { background-color: #ffffcc }
+.highlight pre, pre.code { background: #f0f3f3; }
+.highlight pre .c, pre.code .c { color: #0099FF; font-style: italic } /* Comment */
+.highlight pre .err, pre.code .err { color: #AA0000; background-color: #FFAAAA } /* Error */
+.highlight pre .k, pre.code .k { color: #006699; font-weight: bold } /* Keyword */
+.highlight pre .o, pre.code .o { color: #555555 } /* Operator */
+.highlight pre .cm, pre.code .cm { color: #0099FF; font-style: italic } /* Comment.Multiline */
+.highlight pre .cp, pre.code .cp { color: #009999 } /* Comment.Preproc */
+.highlight pre .c, pre.code .c1 { color: #0099FF; font-style: italic } /* Comment.Single */
+.highlight pre .cs, pre.code .cs { color: #0099FF; font-weight: bold; font-style: italic } /* Comment.Special */
+.highlight pre .gd, pre.code .gd { background-color: #FFCCCC; border: 1px solid #CC0000 } /* Generic.Deleted */
+.highlight pre .ge, pre.code .ge { font-style: italic } /* Generic.Emph */
+.highlight pre .gr, pre.code .gr { color: #FF0000 } /* Generic.Error */
+.highlight pre .gh, pre.code .gh { color: #003300; font-weight: bold } /* Generic.Heading */
+.highlight pre .gi, pre.code .gi { background-color: #CCFFCC; border: 1px solid #00CC00 } /* Generic.Inserted */
+.highlight pre .go, pre.code .go { color: #AAAAAA } /* Generic.Output */
+.highlight pre .gp, pre.code .gp { color: #000099; font-weight: bold } /* Generic.Prompt */
+.highlight pre .gs, pre.code .gs { font-weight: bold } /* Generic.Strong */
+.highlight pre .gu, pre.code .gu { color: #003300; font-weight: bold } /* Generic.Subheading */
+.highlight pre .gt, pre.code .gt { color: #99CC66 } /* Generic.Traceback */
+.highlight pre .kc, pre.code .kc { color: #006699; font-weight: bold } /* Keyword.Constant */
+.highlight pre .kd, pre.code .kd { color: #006699; font-weight: bold } /* Keyword.Declaration */
+.highlight pre .kn, pre.code .kn { color: #006699; font-weight: bold } /* Keyword.Namespace */
+.highlight pre .kp, pre.code .kp { color: #006699 } /* Keyword.Pseudo */
+.highlight pre .kr, pre.code .kr { color: #006699; font-weight: bold } /* Keyword.Reserved */
+.highlight pre .kt, pre.code .kt { color: #007788; font-weight: bold } /* Keyword.Type */
+.highlight pre .m, pre.code .m { color: #FF6600 } /* Literal.Number */
+.highlight pre .s, pre.code .s { color: #CC3300 } /* Literal.String */
+.highlight pre .na, pre.code .na { color: #330099 } /* Name.Attribute */
+.highlight pre .nb, pre.code .nb { color: #336666 } /* Name.Builtin */
+.highlight pre .nc, pre.code .nc { color: #00AA88; font-weight: bold } /* Name.Class */
+.highlight pre .no, pre.code .no { color: #336600 } /* Name.Constant */
+.highlight pre .nd, pre.code .nd { color: #9999FF } /* Name.Decorator */
+.highlight pre .ni, pre.code .ni { color: #999999; font-weight: bold } /* Name.Entity */
+.highlight pre .ne, pre.code .ne { color: #CC0000; font-weight: bold } /* Name.Exception */
+.highlight pre .nf, pre.code .nf { color: #CC00FF } /* Name.Function */
+.highlight pre .nl, pre.code .nl { color: #9999FF } /* Name.Label */
+.highlight pre .nn, pre.code .nn { color: #00CCFF; font-weight: bold } /* Name.Namespace */
+.highlight pre .nt, pre.code .nt { color: #330099; font-weight: bold } /* Name.Tag */
+.highlight pre .nv, pre.code .nv { color: #003333 } /* Name.Variable */
+.highlight pre .ow, pre.code .ow { color: #000000; font-weight: bold } /* Operator.Word */
+.highlight pre .w, pre.code .w { color: #bbbbbb } /* Text.Whitespace */
+.highlight pre .mb, pre.code .mb { color: #FF6600 } /* Literal.Number.Bin */
+.highlight pre .mf, pre.code .mf { color: #FF6600 } /* Literal.Number.Float */
+.highlight pre .mh, pre.code .mh { color: #FF6600 } /* Literal.Number.Hex */
+.highlight pre .mi, pre.code .mi { color: #FF6600 } /* Literal.Number.Integer */
+.highlight pre .mo, pre.code .mo { color: #FF6600 } /* Literal.Number.Oct */
+.highlight pre .sb, pre.code .sb { color: #CC3300 } /* Literal.String.Backtick */
+.highlight pre .sc, pre.code .sc { color: #CC3300 } /* Literal.String.Char */
+.highlight pre .sd, pre.code .sd { color: #CC3300; font-style: italic } /* Literal.String.Doc */
+.highlight pre .s, pre.code .s2 { color: #CC3300 } /* Literal.String.Double */
+.highlight pre .se, pre.code .se { color: #CC3300; font-weight: bold } /* Literal.String.Escape */
+.highlight pre .sh, pre.code .sh { color: #CC3300 } /* Literal.String.Heredoc */
+.highlight pre .si, pre.code .si { color: #AA0000 } /* Literal.String.Interpol */
+.highlight pre .sx, pre.code .sx { color: #CC3300 } /* Literal.String.Other */
+.highlight pre .sr, pre.code .sr { color: #33AAAA } /* Literal.String.Regex */
+.highlight pre .s, pre.code .s1 { color: #CC3300 } /* Literal.String.Single */
+.highlight pre .ss, pre.code .ss { color: #FFCC33 } /* Literal.String.Symbol */
+.highlight pre .bp, pre.code .bp { color: #336666 } /* Name.Builtin.Pseudo */
+.highlight pre .vc, pre.code .vc { color: #003333 } /* Name.Variable.Class */
+.highlight pre .vg, pre.code .vg { color: #003333 } /* Name.Variable.Global */
+.highlight pre .vi, pre.code .vi { color: #003333 } /* Name.Variable.Instance */
+.highlight pre .il, pre.code .il { color: #FF6600 } /* Literal.Number.Integer.Long */

--- a/pelican-bootstrap3/static/css/pygments/monokai.css
+++ b/pelican-bootstrap3/static/css/pygments/monokai.css
@@ -1,64 +1,64 @@
-.highlight pre .hll { background-color: #49483e }
-.highlight pre  { background: #272822; color: #f8f8f2 }
-.highlight pre .c { color: #75715e } /* Comment */
-.highlight pre .err { color: #960050; background-color: #1e0010 } /* Error */
-.highlight pre .k { color: #66d9ef } /* Keyword */
-.highlight pre .l { color: #ae81ff } /* Literal */
-.highlight pre .n { color: #f8f8f2 } /* Name */
-.highlight pre .o { color: #f92672 } /* Operator */
-.highlight pre .p { color: #f8f8f2 } /* Punctuation */
-.highlight pre .cm { color: #75715e } /* Comment.Multiline */
-.highlight pre .cp { color: #75715e } /* Comment.Preproc */
-.highlight pre .c1 { color: #75715e } /* Comment.Single */
-.highlight pre .cs { color: #75715e } /* Comment.Special */
-.highlight pre .gd { color: #f92672 } /* Generic.Deleted */
-.highlight pre .ge { font-style: italic } /* Generic.Emph */
-.highlight pre .gi { color: #a6e22e } /* Generic.Inserted */
-.highlight pre .gs { font-weight: bold } /* Generic.Strong */
-.highlight pre .gu { color: #75715e } /* Generic.Subheading */
-.highlight pre .kc { color: #66d9ef } /* Keyword.Constant */
-.highlight pre .kd { color: #66d9ef } /* Keyword.Declaration */
-.highlight pre .kn { color: #f92672 } /* Keyword.Namespace */
-.highlight pre .kp { color: #66d9ef } /* Keyword.Pseudo */
-.highlight pre .kr { color: #66d9ef } /* Keyword.Reserved */
-.highlight pre .kt { color: #66d9ef } /* Keyword.Type */
-.highlight pre .ld { color: #e6db74 } /* Literal.Date */
-.highlight pre .m { color: #ae81ff } /* Literal.Number */
-.highlight pre .s { color: #e6db74 } /* Literal.String */
-.highlight pre .na { color: #a6e22e } /* Name.Attribute */
-.highlight pre .nb { color: #f8f8f2 } /* Name.Builtin */
-.highlight pre .nc { color: #a6e22e } /* Name.Class */
-.highlight pre .no { color: #66d9ef } /* Name.Constant */
-.highlight pre .nd { color: #a6e22e } /* Name.Decorator */
-.highlight pre .ni { color: #f8f8f2 } /* Name.Entity */
-.highlight pre .ne { color: #a6e22e } /* Name.Exception */
-.highlight pre .nf { color: #a6e22e } /* Name.Function */
-.highlight pre .nl { color: #f8f8f2 } /* Name.Label */
-.highlight pre .nn { color: #f8f8f2 } /* Name.Namespace */
-.highlight pre .nx { color: #a6e22e } /* Name.Other */
-.highlight pre .py { color: #f8f8f2 } /* Name.Property */
-.highlight pre .nt { color: #f92672 } /* Name.Tag */
-.highlight pre .nv { color: #f8f8f2 } /* Name.Variable */
-.highlight pre .ow { color: #f92672 } /* Operator.Word */
-.highlight pre .w { color: #f8f8f2 } /* Text.Whitespace */
-.highlight pre .mb { color: #ae81ff } /* Literal.Number.Bin */
-.highlight pre .mf { color: #ae81ff } /* Literal.Number.Float */
-.highlight pre .mh { color: #ae81ff } /* Literal.Number.Hex */
-.highlight pre .mi { color: #ae81ff } /* Literal.Number.Integer */
-.highlight pre .mo { color: #ae81ff } /* Literal.Number.Oct */
-.highlight pre .sb { color: #e6db74 } /* Literal.String.Backtick */
-.highlight pre .sc { color: #e6db74 } /* Literal.String.Char */
-.highlight pre .sd { color: #e6db74 } /* Literal.String.Doc */
-.highlight pre .s2 { color: #e6db74 } /* Literal.String.Double */
-.highlight pre .se { color: #ae81ff } /* Literal.String.Escape */
-.highlight pre .sh { color: #e6db74 } /* Literal.String.Heredoc */
-.highlight pre .si { color: #e6db74 } /* Literal.String.Interpol */
-.highlight pre .sx { color: #e6db74 } /* Literal.String.Other */
-.highlight pre .sr { color: #e6db74 } /* Literal.String.Regex */
-.highlight pre .s1 { color: #e6db74 } /* Literal.String.Single */
-.highlight pre .ss { color: #e6db74 } /* Literal.String.Symbol */
-.highlight pre .bp { color: #f8f8f2 } /* Name.Builtin.Pseudo */
-.highlight pre .vc { color: #f8f8f2 } /* Name.Variable.Class */
-.highlight pre .vg { color: #f8f8f2 } /* Name.Variable.Global */
-.highlight pre .vi { color: #f8f8f2 } /* Name.Variable.Instance */
-.highlight pre .il { color: #ae81ff } /* Literal.Number.Integer.Long */
+.highlight pre .hll, pre.code .hll { background-color: #49483e }
+.highlight pre, pre.code { background: #272822; color: #f8f8f2 }
+.highlight pre .c, pre.code .c { color: #75715e } /* Comment */
+.highlight pre .err, pre.code .err { color: #960050; background-color: #1e0010 } /* Error */
+.highlight pre .k, pre.code .k { color: #66d9ef } /* Keyword */
+.highlight pre .l, pre.code .l { color: #ae81ff } /* Literal */
+.highlight pre .n, pre.code .n { color: #f8f8f2 } /* Name */
+.highlight pre .o, pre.code .o { color: #f92672 } /* Operator */
+.highlight pre .p, pre.code .p { color: #f8f8f2 } /* Punctuation */
+.highlight pre .cm, pre.code .cm { color: #75715e } /* Comment.Multiline */
+.highlight pre .cp, pre.code .cp { color: #75715e } /* Comment.Preproc */
+.highlight pre .c, pre.code .c1 { color: #75715e } /* Comment.Single */
+.highlight pre .cs, pre.code .cs { color: #75715e } /* Comment.Special */
+.highlight pre .gd, pre.code .gd { color: #f92672 } /* Generic.Deleted */
+.highlight pre .ge, pre.code .ge { font-style: italic } /* Generic.Emph */
+.highlight pre .gi, pre.code .gi { color: #a6e22e } /* Generic.Inserted */
+.highlight pre .gs, pre.code .gs { font-weight: bold } /* Generic.Strong */
+.highlight pre .gu, pre.code .gu { color: #75715e } /* Generic.Subheading */
+.highlight pre .kc, pre.code .kc { color: #66d9ef } /* Keyword.Constant */
+.highlight pre .kd, pre.code .kd { color: #66d9ef } /* Keyword.Declaration */
+.highlight pre .kn, pre.code .kn { color: #f92672 } /* Keyword.Namespace */
+.highlight pre .kp, pre.code .kp { color: #66d9ef } /* Keyword.Pseudo */
+.highlight pre .kr, pre.code .kr { color: #66d9ef } /* Keyword.Reserved */
+.highlight pre .kt, pre.code .kt { color: #66d9ef } /* Keyword.Type */
+.highlight pre .ld, pre.code .ld { color: #e6db74 } /* Literal.Date */
+.highlight pre .m, pre.code .m { color: #ae81ff } /* Literal.Number */
+.highlight pre .s, pre.code .s { color: #e6db74 } /* Literal.String */
+.highlight pre .na, pre.code .na { color: #a6e22e } /* Name.Attribute */
+.highlight pre .nb, pre.code .nb { color: #f8f8f2 } /* Name.Builtin */
+.highlight pre .nc, pre.code .nc { color: #a6e22e } /* Name.Class */
+.highlight pre .no, pre.code .no { color: #66d9ef } /* Name.Constant */
+.highlight pre .nd, pre.code .nd { color: #a6e22e } /* Name.Decorator */
+.highlight pre .ni, pre.code .ni { color: #f8f8f2 } /* Name.Entity */
+.highlight pre .ne, pre.code .ne { color: #a6e22e } /* Name.Exception */
+.highlight pre .nf, pre.code .nf { color: #a6e22e } /* Name.Function */
+.highlight pre .nl, pre.code .nl { color: #f8f8f2 } /* Name.Label */
+.highlight pre .nn, pre.code .nn { color: #f8f8f2 } /* Name.Namespace */
+.highlight pre .nx, pre.code .nx { color: #a6e22e } /* Name.Other */
+.highlight pre .py, pre.code .py { color: #f8f8f2 } /* Name.Property */
+.highlight pre .nt, pre.code .nt { color: #f92672 } /* Name.Tag */
+.highlight pre .nv, pre.code .nv { color: #f8f8f2 } /* Name.Variable */
+.highlight pre .ow, pre.code .ow { color: #f92672 } /* Operator.Word */
+.highlight pre .w, pre.code .w { color: #f8f8f2 } /* Text.Whitespace */
+.highlight pre .mb, pre.code .mb { color: #ae81ff } /* Literal.Number.Bin */
+.highlight pre .mf, pre.code .mf { color: #ae81ff } /* Literal.Number.Float */
+.highlight pre .mh, pre.code .mh { color: #ae81ff } /* Literal.Number.Hex */
+.highlight pre .mi, pre.code .mi { color: #ae81ff } /* Literal.Number.Integer */
+.highlight pre .mo, pre.code .mo { color: #ae81ff } /* Literal.Number.Oct */
+.highlight pre .sb, pre.code .sb { color: #e6db74 } /* Literal.String.Backtick */
+.highlight pre .sc, pre.code .sc { color: #e6db74 } /* Literal.String.Char */
+.highlight pre .sd, pre.code .sd { color: #e6db74 } /* Literal.String.Doc */
+.highlight pre .s, pre.code .s2 { color: #e6db74 } /* Literal.String.Double */
+.highlight pre .se, pre.code .se { color: #ae81ff } /* Literal.String.Escape */
+.highlight pre .sh, pre.code .sh { color: #e6db74 } /* Literal.String.Heredoc */
+.highlight pre .si, pre.code .si { color: #e6db74 } /* Literal.String.Interpol */
+.highlight pre .sx, pre.code .sx { color: #e6db74 } /* Literal.String.Other */
+.highlight pre .sr, pre.code .sr { color: #e6db74 } /* Literal.String.Regex */
+.highlight pre .s, pre.code .s1 { color: #e6db74 } /* Literal.String.Single */
+.highlight pre .ss, pre.code .ss { color: #e6db74 } /* Literal.String.Symbol */
+.highlight pre .bp, pre.code .bp { color: #f8f8f2 } /* Name.Builtin.Pseudo */
+.highlight pre .vc, pre.code .vc { color: #f8f8f2 } /* Name.Variable.Class */
+.highlight pre .vg, pre.code .vg { color: #f8f8f2 } /* Name.Variable.Global */
+.highlight pre .vi, pre.code .vi { color: #f8f8f2 } /* Name.Variable.Instance */
+.highlight pre .il, pre.code .il { color: #ae81ff } /* Literal.Number.Integer.Long */

--- a/pelican-bootstrap3/static/css/pygments/murphy.css
+++ b/pelican-bootstrap3/static/css/pygments/murphy.css
@@ -1,63 +1,63 @@
-.highlight pre .hll { background-color: #ffffcc }
-.highlight pre  { background: #ffffff; }
-.highlight pre .c { color: #666666; font-style: italic } /* Comment */
-.highlight pre .err { color: #FF0000; background-color: #FFAAAA } /* Error */
-.highlight pre .k { color: #228899; font-weight: bold } /* Keyword */
-.highlight pre .o { color: #333333 } /* Operator */
-.highlight pre .cm { color: #666666; font-style: italic } /* Comment.Multiline */
-.highlight pre .cp { color: #557799 } /* Comment.Preproc */
-.highlight pre .c1 { color: #666666; font-style: italic } /* Comment.Single */
-.highlight pre .cs { color: #cc0000; font-weight: bold; font-style: italic } /* Comment.Special */
-.highlight pre .gd { color: #A00000 } /* Generic.Deleted */
-.highlight pre .ge { font-style: italic } /* Generic.Emph */
-.highlight pre .gr { color: #FF0000 } /* Generic.Error */
-.highlight pre .gh { color: #000080; font-weight: bold } /* Generic.Heading */
-.highlight pre .gi { color: #00A000 } /* Generic.Inserted */
-.highlight pre .go { color: #888888 } /* Generic.Output */
-.highlight pre .gp { color: #c65d09; font-weight: bold } /* Generic.Prompt */
-.highlight pre .gs { font-weight: bold } /* Generic.Strong */
-.highlight pre .gu { color: #800080; font-weight: bold } /* Generic.Subheading */
-.highlight pre .gt { color: #0044DD } /* Generic.Traceback */
-.highlight pre .kc { color: #228899; font-weight: bold } /* Keyword.Constant */
-.highlight pre .kd { color: #228899; font-weight: bold } /* Keyword.Declaration */
-.highlight pre .kn { color: #228899; font-weight: bold } /* Keyword.Namespace */
-.highlight pre .kp { color: #0088ff; font-weight: bold } /* Keyword.Pseudo */
-.highlight pre .kr { color: #228899; font-weight: bold } /* Keyword.Reserved */
-.highlight pre .kt { color: #6666ff; font-weight: bold } /* Keyword.Type */
-.highlight pre .m { color: #6600EE; font-weight: bold } /* Literal.Number */
-.highlight pre .s { background-color: #e0e0ff } /* Literal.String */
-.highlight pre .na { color: #000077 } /* Name.Attribute */
-.highlight pre .nb { color: #007722 } /* Name.Builtin */
-.highlight pre .nc { color: #ee99ee; font-weight: bold } /* Name.Class */
-.highlight pre .no { color: #55eedd; font-weight: bold } /* Name.Constant */
-.highlight pre .nd { color: #555555; font-weight: bold } /* Name.Decorator */
-.highlight pre .ni { color: #880000 } /* Name.Entity */
-.highlight pre .ne { color: #FF0000; font-weight: bold } /* Name.Exception */
-.highlight pre .nf { color: #55eedd; font-weight: bold } /* Name.Function */
-.highlight pre .nl { color: #997700; font-weight: bold } /* Name.Label */
-.highlight pre .nn { color: #0e84b5; font-weight: bold } /* Name.Namespace */
-.highlight pre .nt { color: #007700 } /* Name.Tag */
-.highlight pre .nv { color: #003366 } /* Name.Variable */
-.highlight pre .ow { color: #000000; font-weight: bold } /* Operator.Word */
-.highlight pre .w { color: #bbbbbb } /* Text.Whitespace */
-.highlight pre .mb { color: #6600EE; font-weight: bold } /* Literal.Number.Bin */
-.highlight pre .mf { color: #6600EE; font-weight: bold } /* Literal.Number.Float */
-.highlight pre .mh { color: #005588; font-weight: bold } /* Literal.Number.Hex */
-.highlight pre .mi { color: #6666ff; font-weight: bold } /* Literal.Number.Integer */
-.highlight pre .mo { color: #4400EE; font-weight: bold } /* Literal.Number.Oct */
-.highlight pre .sb { background-color: #e0e0ff } /* Literal.String.Backtick */
-.highlight pre .sc { color: #8888FF } /* Literal.String.Char */
-.highlight pre .sd { color: #DD4422 } /* Literal.String.Doc */
-.highlight pre .s2 { background-color: #e0e0ff } /* Literal.String.Double */
-.highlight pre .se { color: #666666; font-weight: bold; background-color: #e0e0ff } /* Literal.String.Escape */
-.highlight pre .sh { background-color: #e0e0ff } /* Literal.String.Heredoc */
-.highlight pre .si { background-color: #eeeeee } /* Literal.String.Interpol */
-.highlight pre .sx { color: #ff8888; background-color: #e0e0ff } /* Literal.String.Other */
-.highlight pre .sr { color: #000000; background-color: #e0e0ff } /* Literal.String.Regex */
-.highlight pre .s1 { background-color: #e0e0ff } /* Literal.String.Single */
-.highlight pre .ss { color: #ffcc88 } /* Literal.String.Symbol */
-.highlight pre .bp { color: #007722 } /* Name.Builtin.Pseudo */
-.highlight pre .vc { color: #ccccff } /* Name.Variable.Class */
-.highlight pre .vg { color: #ff8844 } /* Name.Variable.Global */
-.highlight pre .vi { color: #aaaaff } /* Name.Variable.Instance */
-.highlight pre .il { color: #6666ff; font-weight: bold } /* Literal.Number.Integer.Long */
+.highlight pre .hll, pre.code .hll { background-color: #ffffcc }
+.highlight pre, pre.code { background: #ffffff; }
+.highlight pre .c, pre.code .c { color: #666666; font-style: italic } /* Comment */
+.highlight pre .err, pre.code .err { color: #FF0000; background-color: #FFAAAA } /* Error */
+.highlight pre .k, pre.code .k { color: #228899; font-weight: bold } /* Keyword */
+.highlight pre .o, pre.code .o { color: #333333 } /* Operator */
+.highlight pre .cm, pre.code .cm { color: #666666; font-style: italic } /* Comment.Multiline */
+.highlight pre .cp, pre.code .cp { color: #557799 } /* Comment.Preproc */
+.highlight pre .c, pre.code .c1 { color: #666666; font-style: italic } /* Comment.Single */
+.highlight pre .cs, pre.code .cs { color: #cc0000; font-weight: bold; font-style: italic } /* Comment.Special */
+.highlight pre .gd, pre.code .gd { color: #A00000 } /* Generic.Deleted */
+.highlight pre .ge, pre.code .ge { font-style: italic } /* Generic.Emph */
+.highlight pre .gr, pre.code .gr { color: #FF0000 } /* Generic.Error */
+.highlight pre .gh, pre.code .gh { color: #000080; font-weight: bold } /* Generic.Heading */
+.highlight pre .gi, pre.code .gi { color: #00A000 } /* Generic.Inserted */
+.highlight pre .go, pre.code .go { color: #888888 } /* Generic.Output */
+.highlight pre .gp, pre.code .gp { color: #c65d09; font-weight: bold } /* Generic.Prompt */
+.highlight pre .gs, pre.code .gs { font-weight: bold } /* Generic.Strong */
+.highlight pre .gu, pre.code .gu { color: #800080; font-weight: bold } /* Generic.Subheading */
+.highlight pre .gt, pre.code .gt { color: #0044DD } /* Generic.Traceback */
+.highlight pre .kc, pre.code .kc { color: #228899; font-weight: bold } /* Keyword.Constant */
+.highlight pre .kd, pre.code .kd { color: #228899; font-weight: bold } /* Keyword.Declaration */
+.highlight pre .kn, pre.code .kn { color: #228899; font-weight: bold } /* Keyword.Namespace */
+.highlight pre .kp, pre.code .kp { color: #0088ff; font-weight: bold } /* Keyword.Pseudo */
+.highlight pre .kr, pre.code .kr { color: #228899; font-weight: bold } /* Keyword.Reserved */
+.highlight pre .kt, pre.code .kt { color: #6666ff; font-weight: bold } /* Keyword.Type */
+.highlight pre .m, pre.code .m { color: #6600EE; font-weight: bold } /* Literal.Number */
+.highlight pre .s, pre.code .s { background-color: #e0e0ff } /* Literal.String */
+.highlight pre .na, pre.code .na { color: #000077 } /* Name.Attribute */
+.highlight pre .nb, pre.code .nb { color: #007722 } /* Name.Builtin */
+.highlight pre .nc, pre.code .nc { color: #ee99ee; font-weight: bold } /* Name.Class */
+.highlight pre .no, pre.code .no { color: #55eedd; font-weight: bold } /* Name.Constant */
+.highlight pre .nd, pre.code .nd { color: #555555; font-weight: bold } /* Name.Decorator */
+.highlight pre .ni, pre.code .ni { color: #880000 } /* Name.Entity */
+.highlight pre .ne, pre.code .ne { color: #FF0000; font-weight: bold } /* Name.Exception */
+.highlight pre .nf, pre.code .nf { color: #55eedd; font-weight: bold } /* Name.Function */
+.highlight pre .nl, pre.code .nl { color: #997700; font-weight: bold } /* Name.Label */
+.highlight pre .nn, pre.code .nn { color: #0e84b5; font-weight: bold } /* Name.Namespace */
+.highlight pre .nt, pre.code .nt { color: #007700 } /* Name.Tag */
+.highlight pre .nv, pre.code .nv { color: #003366 } /* Name.Variable */
+.highlight pre .ow, pre.code .ow { color: #000000; font-weight: bold } /* Operator.Word */
+.highlight pre .w, pre.code .w { color: #bbbbbb } /* Text.Whitespace */
+.highlight pre .mb, pre.code .mb { color: #6600EE; font-weight: bold } /* Literal.Number.Bin */
+.highlight pre .mf, pre.code .mf { color: #6600EE; font-weight: bold } /* Literal.Number.Float */
+.highlight pre .mh, pre.code .mh { color: #005588; font-weight: bold } /* Literal.Number.Hex */
+.highlight pre .mi, pre.code .mi { color: #6666ff; font-weight: bold } /* Literal.Number.Integer */
+.highlight pre .mo, pre.code .mo { color: #4400EE; font-weight: bold } /* Literal.Number.Oct */
+.highlight pre .sb, pre.code .sb { background-color: #e0e0ff } /* Literal.String.Backtick */
+.highlight pre .sc, pre.code .sc { color: #8888FF } /* Literal.String.Char */
+.highlight pre .sd, pre.code .sd { color: #DD4422 } /* Literal.String.Doc */
+.highlight pre .s, pre.code .s2 { background-color: #e0e0ff } /* Literal.String.Double */
+.highlight pre .se, pre.code .se { color: #666666; font-weight: bold; background-color: #e0e0ff } /* Literal.String.Escape */
+.highlight pre .sh, pre.code .sh { background-color: #e0e0ff } /* Literal.String.Heredoc */
+.highlight pre .si, pre.code .si { background-color: #eeeeee } /* Literal.String.Interpol */
+.highlight pre .sx, pre.code .sx { color: #ff8888; background-color: #e0e0ff } /* Literal.String.Other */
+.highlight pre .sr, pre.code .sr { color: #000000; background-color: #e0e0ff } /* Literal.String.Regex */
+.highlight pre .s, pre.code .s1 { background-color: #e0e0ff } /* Literal.String.Single */
+.highlight pre .ss, pre.code .ss { color: #ffcc88 } /* Literal.String.Symbol */
+.highlight pre .bp, pre.code .bp { color: #007722 } /* Name.Builtin.Pseudo */
+.highlight pre .vc, pre.code .vc { color: #ccccff } /* Name.Variable.Class */
+.highlight pre .vg, pre.code .vg { color: #ff8844 } /* Name.Variable.Global */
+.highlight pre .vi, pre.code .vi { color: #aaaaff } /* Name.Variable.Instance */
+.highlight pre .il, pre.code .il { color: #6666ff; font-weight: bold } /* Literal.Number.Integer.Long */

--- a/pelican-bootstrap3/static/css/pygments/native.css
+++ b/pelican-bootstrap3/static/css/pygments/native.css
@@ -1,72 +1,72 @@
-.highlight pre .hll { background-color: #404040 }
-.highlight pre  { background: #202020; color: #d0d0d0 }
-.highlight pre .c { color: #999999; font-style: italic } /* Comment */
-.highlight pre .err { color: #a61717; background-color: #e3d2d2 } /* Error */
-.highlight pre .esc { color: #d0d0d0 } /* Escape */
-.highlight pre .g { color: #d0d0d0 } /* Generic */
-.highlight pre .k { color: #6ab825; font-weight: bold } /* Keyword */
-.highlight pre .l { color: #d0d0d0 } /* Literal */
-.highlight pre .n { color: #d0d0d0 } /* Name */
-.highlight pre .o { color: #d0d0d0 } /* Operator */
-.highlight pre .x { color: #d0d0d0 } /* Other */
-.highlight pre .p { color: #d0d0d0 } /* Punctuation */
-.highlight pre .cm { color: #999999; font-style: italic } /* Comment.Multiline */
-.highlight pre .cp { color: #cd2828; font-weight: bold } /* Comment.Preproc */
-.highlight pre .c1 { color: #999999; font-style: italic } /* Comment.Single */
-.highlight pre .cs { color: #e50808; font-weight: bold; background-color: #520000 } /* Comment.Special */
-.highlight pre .gd { color: #d22323 } /* Generic.Deleted */
-.highlight pre .ge { color: #d0d0d0; font-style: italic } /* Generic.Emph */
-.highlight pre .gr { color: #d22323 } /* Generic.Error */
-.highlight pre .gh { color: #ffffff; font-weight: bold } /* Generic.Heading */
-.highlight pre .gi { color: #589819 } /* Generic.Inserted */
-.highlight pre .go { color: #cccccc } /* Generic.Output */
-.highlight pre .gp { color: #aaaaaa } /* Generic.Prompt */
-.highlight pre .gs { color: #d0d0d0; font-weight: bold } /* Generic.Strong */
-.highlight pre .gu { color: #ffffff; text-decoration: underline } /* Generic.Subheading */
-.highlight pre .gt { color: #d22323 } /* Generic.Traceback */
-.highlight pre .kc { color: #6ab825; font-weight: bold } /* Keyword.Constant */
-.highlight pre .kd { color: #6ab825; font-weight: bold } /* Keyword.Declaration */
-.highlight pre .kn { color: #6ab825; font-weight: bold } /* Keyword.Namespace */
-.highlight pre .kp { color: #6ab825 } /* Keyword.Pseudo */
-.highlight pre .kr { color: #6ab825; font-weight: bold } /* Keyword.Reserved */
-.highlight pre .kt { color: #6ab825; font-weight: bold } /* Keyword.Type */
-.highlight pre .ld { color: #d0d0d0 } /* Literal.Date */
-.highlight pre .m { color: #3677a9 } /* Literal.Number */
-.highlight pre .s { color: #ed9d13 } /* Literal.String */
-.highlight pre .na { color: #bbbbbb } /* Name.Attribute */
-.highlight pre .nb { color: #24909d } /* Name.Builtin */
-.highlight pre .nc { color: #447fcf; text-decoration: underline } /* Name.Class */
-.highlight pre .no { color: #40ffff } /* Name.Constant */
-.highlight pre .nd { color: #ffa500 } /* Name.Decorator */
-.highlight pre .ni { color: #d0d0d0 } /* Name.Entity */
-.highlight pre .ne { color: #bbbbbb } /* Name.Exception */
-.highlight pre .nf { color: #447fcf } /* Name.Function */
-.highlight pre .nl { color: #d0d0d0 } /* Name.Label */
-.highlight pre .nn { color: #447fcf; text-decoration: underline } /* Name.Namespace */
-.highlight pre .nx { color: #d0d0d0 } /* Name.Other */
-.highlight pre .py { color: #d0d0d0 } /* Name.Property */
-.highlight pre .nt { color: #6ab825; font-weight: bold } /* Name.Tag */
-.highlight pre .nv { color: #40ffff } /* Name.Variable */
-.highlight pre .ow { color: #6ab825; font-weight: bold } /* Operator.Word */
-.highlight pre .w { color: #666666 } /* Text.Whitespace */
-.highlight pre .mb { color: #3677a9 } /* Literal.Number.Bin */
-.highlight pre .mf { color: #3677a9 } /* Literal.Number.Float */
-.highlight pre .mh { color: #3677a9 } /* Literal.Number.Hex */
-.highlight pre .mi { color: #3677a9 } /* Literal.Number.Integer */
-.highlight pre .mo { color: #3677a9 } /* Literal.Number.Oct */
-.highlight pre .sb { color: #ed9d13 } /* Literal.String.Backtick */
-.highlight pre .sc { color: #ed9d13 } /* Literal.String.Char */
-.highlight pre .sd { color: #ed9d13 } /* Literal.String.Doc */
-.highlight pre .s2 { color: #ed9d13 } /* Literal.String.Double */
-.highlight pre .se { color: #ed9d13 } /* Literal.String.Escape */
-.highlight pre .sh { color: #ed9d13 } /* Literal.String.Heredoc */
-.highlight pre .si { color: #ed9d13 } /* Literal.String.Interpol */
-.highlight pre .sx { color: #ffa500 } /* Literal.String.Other */
-.highlight pre .sr { color: #ed9d13 } /* Literal.String.Regex */
-.highlight pre .s1 { color: #ed9d13 } /* Literal.String.Single */
-.highlight pre .ss { color: #ed9d13 } /* Literal.String.Symbol */
-.highlight pre .bp { color: #24909d } /* Name.Builtin.Pseudo */
-.highlight pre .vc { color: #40ffff } /* Name.Variable.Class */
-.highlight pre .vg { color: #40ffff } /* Name.Variable.Global */
-.highlight pre .vi { color: #40ffff } /* Name.Variable.Instance */
-.highlight pre .il { color: #3677a9 } /* Literal.Number.Integer.Long */
+.highlight pre .hll, pre.code .hll { background-color: #404040 }
+.highlight pre, pre.code { background: #202020; color: #d0d0d0 }
+.highlight pre .c, pre.code .c { color: #999999; font-style: italic } /* Comment */
+.highlight pre .err, pre.code .err { color: #a61717; background-color: #e3d2d2 } /* Error */
+.highlight pre .esc, pre.code .esc { color: #d0d0d0 } /* Escape */
+.highlight pre .g, pre.code .g { color: #d0d0d0 } /* Generic */
+.highlight pre .k, pre.code .k { color: #6ab825; font-weight: bold } /* Keyword */
+.highlight pre .l, pre.code .l { color: #d0d0d0 } /* Literal */
+.highlight pre .n, pre.code .n { color: #d0d0d0 } /* Name */
+.highlight pre .o, pre.code .o { color: #d0d0d0 } /* Operator */
+.highlight pre .x, pre.code .x { color: #d0d0d0 } /* Other */
+.highlight pre .p, pre.code .p { color: #d0d0d0 } /* Punctuation */
+.highlight pre .cm, pre.code .cm { color: #999999; font-style: italic } /* Comment.Multiline */
+.highlight pre .cp, pre.code .cp { color: #cd2828; font-weight: bold } /* Comment.Preproc */
+.highlight pre .c, pre.code .c1 { color: #999999; font-style: italic } /* Comment.Single */
+.highlight pre .cs, pre.code .cs { color: #e50808; font-weight: bold; background-color: #520000 } /* Comment.Special */
+.highlight pre .gd, pre.code .gd { color: #d22323 } /* Generic.Deleted */
+.highlight pre .ge, pre.code .ge { color: #d0d0d0; font-style: italic } /* Generic.Emph */
+.highlight pre .gr, pre.code .gr { color: #d22323 } /* Generic.Error */
+.highlight pre .gh, pre.code .gh { color: #ffffff; font-weight: bold } /* Generic.Heading */
+.highlight pre .gi, pre.code .gi { color: #589819 } /* Generic.Inserted */
+.highlight pre .go, pre.code .go { color: #cccccc } /* Generic.Output */
+.highlight pre .gp, pre.code .gp { color: #aaaaaa } /* Generic.Prompt */
+.highlight pre .gs, pre.code .gs { color: #d0d0d0; font-weight: bold } /* Generic.Strong */
+.highlight pre .gu, pre.code .gu { color: #ffffff; text-decoration: underline } /* Generic.Subheading */
+.highlight pre .gt, pre.code .gt { color: #d22323 } /* Generic.Traceback */
+.highlight pre .kc, pre.code .kc { color: #6ab825; font-weight: bold } /* Keyword.Constant */
+.highlight pre .kd, pre.code .kd { color: #6ab825; font-weight: bold } /* Keyword.Declaration */
+.highlight pre .kn, pre.code .kn { color: #6ab825; font-weight: bold } /* Keyword.Namespace */
+.highlight pre .kp, pre.code .kp { color: #6ab825 } /* Keyword.Pseudo */
+.highlight pre .kr, pre.code .kr { color: #6ab825; font-weight: bold } /* Keyword.Reserved */
+.highlight pre .kt, pre.code .kt { color: #6ab825; font-weight: bold } /* Keyword.Type */
+.highlight pre .ld, pre.code .ld { color: #d0d0d0 } /* Literal.Date */
+.highlight pre .m, pre.code .m { color: #3677a9 } /* Literal.Number */
+.highlight pre .s, pre.code .s { color: #ed9d13 } /* Literal.String */
+.highlight pre .na, pre.code .na { color: #bbbbbb } /* Name.Attribute */
+.highlight pre .nb, pre.code .nb { color: #24909d } /* Name.Builtin */
+.highlight pre .nc, pre.code .nc { color: #447fcf; text-decoration: underline } /* Name.Class */
+.highlight pre .no, pre.code .no { color: #40ffff } /* Name.Constant */
+.highlight pre .nd, pre.code .nd { color: #ffa500 } /* Name.Decorator */
+.highlight pre .ni, pre.code .ni { color: #d0d0d0 } /* Name.Entity */
+.highlight pre .ne, pre.code .ne { color: #bbbbbb } /* Name.Exception */
+.highlight pre .nf, pre.code .nf { color: #447fcf } /* Name.Function */
+.highlight pre .nl, pre.code .nl { color: #d0d0d0 } /* Name.Label */
+.highlight pre .nn, pre.code .nn { color: #447fcf; text-decoration: underline } /* Name.Namespace */
+.highlight pre .nx, pre.code .nx { color: #d0d0d0 } /* Name.Other */
+.highlight pre .py, pre.code .py { color: #d0d0d0 } /* Name.Property */
+.highlight pre .nt, pre.code .nt { color: #6ab825; font-weight: bold } /* Name.Tag */
+.highlight pre .nv, pre.code .nv { color: #40ffff } /* Name.Variable */
+.highlight pre .ow, pre.code .ow { color: #6ab825; font-weight: bold } /* Operator.Word */
+.highlight pre .w, pre.code .w { color: #666666 } /* Text.Whitespace */
+.highlight pre .mb, pre.code .mb { color: #3677a9 } /* Literal.Number.Bin */
+.highlight pre .mf, pre.code .mf { color: #3677a9 } /* Literal.Number.Float */
+.highlight pre .mh, pre.code .mh { color: #3677a9 } /* Literal.Number.Hex */
+.highlight pre .mi, pre.code .mi { color: #3677a9 } /* Literal.Number.Integer */
+.highlight pre .mo, pre.code .mo { color: #3677a9 } /* Literal.Number.Oct */
+.highlight pre .sb, pre.code .sb { color: #ed9d13 } /* Literal.String.Backtick */
+.highlight pre .sc, pre.code .sc { color: #ed9d13 } /* Literal.String.Char */
+.highlight pre .sd, pre.code .sd { color: #ed9d13 } /* Literal.String.Doc */
+.highlight pre .s, pre.code .s2 { color: #ed9d13 } /* Literal.String.Double */
+.highlight pre .se, pre.code .se { color: #ed9d13 } /* Literal.String.Escape */
+.highlight pre .sh, pre.code .sh { color: #ed9d13 } /* Literal.String.Heredoc */
+.highlight pre .si, pre.code .si { color: #ed9d13 } /* Literal.String.Interpol */
+.highlight pre .sx, pre.code .sx { color: #ffa500 } /* Literal.String.Other */
+.highlight pre .sr, pre.code .sr { color: #ed9d13 } /* Literal.String.Regex */
+.highlight pre .s, pre.code .s1 { color: #ed9d13 } /* Literal.String.Single */
+.highlight pre .ss, pre.code .ss { color: #ed9d13 } /* Literal.String.Symbol */
+.highlight pre .bp, pre.code .bp { color: #24909d } /* Name.Builtin.Pseudo */
+.highlight pre .vc, pre.code .vc { color: #40ffff } /* Name.Variable.Class */
+.highlight pre .vg, pre.code .vg { color: #40ffff } /* Name.Variable.Global */
+.highlight pre .vi, pre.code .vi { color: #40ffff } /* Name.Variable.Instance */
+.highlight pre .il, pre.code .il { color: #3677a9 } /* Literal.Number.Integer.Long */

--- a/pelican-bootstrap3/static/css/pygments/paraiso-dark.css
+++ b/pelican-bootstrap3/static/css/pygments/paraiso-dark.css
@@ -1,66 +1,66 @@
-.highlight pre .hll { background-color: #4f424c }
-.highlight pre  { background: #2f1e2e; color: #e7e9db }
-.highlight pre .c { color: #776e71 } /* Comment */
-.highlight pre .err { color: #ef6155 } /* Error */
-.highlight pre .k { color: #815ba4 } /* Keyword */
-.highlight pre .l { color: #f99b15 } /* Literal */
-.highlight pre .n { color: #e7e9db } /* Name */
-.highlight pre .o { color: #5bc4bf } /* Operator */
-.highlight pre .p { color: #e7e9db } /* Punctuation */
-.highlight pre .cm { color: #776e71 } /* Comment.Multiline */
-.highlight pre .cp { color: #776e71 } /* Comment.Preproc */
-.highlight pre .c1 { color: #776e71 } /* Comment.Single */
-.highlight pre .cs { color: #776e71 } /* Comment.Special */
-.highlight pre .gd { color: #ef6155 } /* Generic.Deleted */
-.highlight pre .ge { font-style: italic } /* Generic.Emph */
-.highlight pre .gh { color: #e7e9db; font-weight: bold } /* Generic.Heading */
-.highlight pre .gi { color: #48b685 } /* Generic.Inserted */
-.highlight pre .gp { color: #776e71; font-weight: bold } /* Generic.Prompt */
-.highlight pre .gs { font-weight: bold } /* Generic.Strong */
-.highlight pre .gu { color: #5bc4bf; font-weight: bold } /* Generic.Subheading */
-.highlight pre .kc { color: #815ba4 } /* Keyword.Constant */
-.highlight pre .kd { color: #815ba4 } /* Keyword.Declaration */
-.highlight pre .kn { color: #5bc4bf } /* Keyword.Namespace */
-.highlight pre .kp { color: #815ba4 } /* Keyword.Pseudo */
-.highlight pre .kr { color: #815ba4 } /* Keyword.Reserved */
-.highlight pre .kt { color: #fec418 } /* Keyword.Type */
-.highlight pre .ld { color: #48b685 } /* Literal.Date */
-.highlight pre .m { color: #f99b15 } /* Literal.Number */
-.highlight pre .s { color: #48b685 } /* Literal.String */
-.highlight pre .na { color: #06b6ef } /* Name.Attribute */
-.highlight pre .nb { color: #e7e9db } /* Name.Builtin */
-.highlight pre .nc { color: #fec418 } /* Name.Class */
-.highlight pre .no { color: #ef6155 } /* Name.Constant */
-.highlight pre .nd { color: #5bc4bf } /* Name.Decorator */
-.highlight pre .ni { color: #e7e9db } /* Name.Entity */
-.highlight pre .ne { color: #ef6155 } /* Name.Exception */
-.highlight pre .nf { color: #06b6ef } /* Name.Function */
-.highlight pre .nl { color: #e7e9db } /* Name.Label */
-.highlight pre .nn { color: #fec418 } /* Name.Namespace */
-.highlight pre .nx { color: #06b6ef } /* Name.Other */
-.highlight pre .py { color: #e7e9db } /* Name.Property */
-.highlight pre .nt { color: #5bc4bf } /* Name.Tag */
-.highlight pre .nv { color: #ef6155 } /* Name.Variable */
-.highlight pre .ow { color: #5bc4bf } /* Operator.Word */
-.highlight pre .w { color: #e7e9db } /* Text.Whitespace */
-.highlight pre .mb { color: #f99b15 } /* Literal.Number.Bin */
-.highlight pre .mf { color: #f99b15 } /* Literal.Number.Float */
-.highlight pre .mh { color: #f99b15 } /* Literal.Number.Hex */
-.highlight pre .mi { color: #f99b15 } /* Literal.Number.Integer */
-.highlight pre .mo { color: #f99b15 } /* Literal.Number.Oct */
-.highlight pre .sb { color: #48b685 } /* Literal.String.Backtick */
-.highlight pre .sc { color: #e7e9db } /* Literal.String.Char */
-.highlight pre .sd { color: #776e71 } /* Literal.String.Doc */
-.highlight pre .s2 { color: #48b685 } /* Literal.String.Double */
-.highlight pre .se { color: #f99b15 } /* Literal.String.Escape */
-.highlight pre .sh { color: #48b685 } /* Literal.String.Heredoc */
-.highlight pre .si { color: #f99b15 } /* Literal.String.Interpol */
-.highlight pre .sx { color: #48b685 } /* Literal.String.Other */
-.highlight pre .sr { color: #48b685 } /* Literal.String.Regex */
-.highlight pre .s1 { color: #48b685 } /* Literal.String.Single */
-.highlight pre .ss { color: #48b685 } /* Literal.String.Symbol */
-.highlight pre .bp { color: #e7e9db } /* Name.Builtin.Pseudo */
-.highlight pre .vc { color: #ef6155 } /* Name.Variable.Class */
-.highlight pre .vg { color: #ef6155 } /* Name.Variable.Global */
-.highlight pre .vi { color: #ef6155 } /* Name.Variable.Instance */
-.highlight pre .il { color: #f99b15 } /* Literal.Number.Integer.Long */
+.highlight pre .hll, pre.code .hll { background-color: #4f424c }
+.highlight pre, pre.code { background: #2f1e2e; color: #e7e9db }
+.highlight pre .c, pre.code .c { color: #776e71 } /* Comment */
+.highlight pre .err, pre.code .err { color: #ef6155 } /* Error */
+.highlight pre .k, pre.code .k { color: #815ba4 } /* Keyword */
+.highlight pre .l, pre.code .l { color: #f99b15 } /* Literal */
+.highlight pre .n, pre.code .n { color: #e7e9db } /* Name */
+.highlight pre .o, pre.code .o { color: #5bc4bf } /* Operator */
+.highlight pre .p, pre.code .p { color: #e7e9db } /* Punctuation */
+.highlight pre .cm, pre.code .cm { color: #776e71 } /* Comment.Multiline */
+.highlight pre .cp, pre.code .cp { color: #776e71 } /* Comment.Preproc */
+.highlight pre .c, pre.code .c1 { color: #776e71 } /* Comment.Single */
+.highlight pre .cs, pre.code .cs { color: #776e71 } /* Comment.Special */
+.highlight pre .gd, pre.code .gd { color: #ef6155 } /* Generic.Deleted */
+.highlight pre .ge, pre.code .ge { font-style: italic } /* Generic.Emph */
+.highlight pre .gh, pre.code .gh { color: #e7e9db; font-weight: bold } /* Generic.Heading */
+.highlight pre .gi, pre.code .gi { color: #48b685 } /* Generic.Inserted */
+.highlight pre .gp, pre.code .gp { color: #776e71; font-weight: bold } /* Generic.Prompt */
+.highlight pre .gs, pre.code .gs { font-weight: bold } /* Generic.Strong */
+.highlight pre .gu, pre.code .gu { color: #5bc4bf; font-weight: bold } /* Generic.Subheading */
+.highlight pre .kc, pre.code .kc { color: #815ba4 } /* Keyword.Constant */
+.highlight pre .kd, pre.code .kd { color: #815ba4 } /* Keyword.Declaration */
+.highlight pre .kn, pre.code .kn { color: #5bc4bf } /* Keyword.Namespace */
+.highlight pre .kp, pre.code .kp { color: #815ba4 } /* Keyword.Pseudo */
+.highlight pre .kr, pre.code .kr { color: #815ba4 } /* Keyword.Reserved */
+.highlight pre .kt, pre.code .kt { color: #fec418 } /* Keyword.Type */
+.highlight pre .ld, pre.code .ld { color: #48b685 } /* Literal.Date */
+.highlight pre .m, pre.code .m { color: #f99b15 } /* Literal.Number */
+.highlight pre .s, pre.code .s { color: #48b685 } /* Literal.String */
+.highlight pre .na, pre.code .na { color: #06b6ef } /* Name.Attribute */
+.highlight pre .nb, pre.code .nb { color: #e7e9db } /* Name.Builtin */
+.highlight pre .nc, pre.code .nc { color: #fec418 } /* Name.Class */
+.highlight pre .no, pre.code .no { color: #ef6155 } /* Name.Constant */
+.highlight pre .nd, pre.code .nd { color: #5bc4bf } /* Name.Decorator */
+.highlight pre .ni, pre.code .ni { color: #e7e9db } /* Name.Entity */
+.highlight pre .ne, pre.code .ne { color: #ef6155 } /* Name.Exception */
+.highlight pre .nf, pre.code .nf { color: #06b6ef } /* Name.Function */
+.highlight pre .nl, pre.code .nl { color: #e7e9db } /* Name.Label */
+.highlight pre .nn, pre.code .nn { color: #fec418 } /* Name.Namespace */
+.highlight pre .nx, pre.code .nx { color: #06b6ef } /* Name.Other */
+.highlight pre .py, pre.code .py { color: #e7e9db } /* Name.Property */
+.highlight pre .nt, pre.code .nt { color: #5bc4bf } /* Name.Tag */
+.highlight pre .nv, pre.code .nv { color: #ef6155 } /* Name.Variable */
+.highlight pre .ow, pre.code .ow { color: #5bc4bf } /* Operator.Word */
+.highlight pre .w, pre.code .w { color: #e7e9db } /* Text.Whitespace */
+.highlight pre .mb, pre.code .mb { color: #f99b15 } /* Literal.Number.Bin */
+.highlight pre .mf, pre.code .mf { color: #f99b15 } /* Literal.Number.Float */
+.highlight pre .mh, pre.code .mh { color: #f99b15 } /* Literal.Number.Hex */
+.highlight pre .mi, pre.code .mi { color: #f99b15 } /* Literal.Number.Integer */
+.highlight pre .mo, pre.code .mo { color: #f99b15 } /* Literal.Number.Oct */
+.highlight pre .sb, pre.code .sb { color: #48b685 } /* Literal.String.Backtick */
+.highlight pre .sc, pre.code .sc { color: #e7e9db } /* Literal.String.Char */
+.highlight pre .sd, pre.code .sd { color: #776e71 } /* Literal.String.Doc */
+.highlight pre .s, pre.code .s2 { color: #48b685 } /* Literal.String.Double */
+.highlight pre .se, pre.code .se { color: #f99b15 } /* Literal.String.Escape */
+.highlight pre .sh, pre.code .sh { color: #48b685 } /* Literal.String.Heredoc */
+.highlight pre .si, pre.code .si { color: #f99b15 } /* Literal.String.Interpol */
+.highlight pre .sx, pre.code .sx { color: #48b685 } /* Literal.String.Other */
+.highlight pre .sr, pre.code .sr { color: #48b685 } /* Literal.String.Regex */
+.highlight pre .s, pre.code .s1 { color: #48b685 } /* Literal.String.Single */
+.highlight pre .ss, pre.code .ss { color: #48b685 } /* Literal.String.Symbol */
+.highlight pre .bp, pre.code .bp { color: #e7e9db } /* Name.Builtin.Pseudo */
+.highlight pre .vc, pre.code .vc { color: #ef6155 } /* Name.Variable.Class */
+.highlight pre .vg, pre.code .vg { color: #ef6155 } /* Name.Variable.Global */
+.highlight pre .vi, pre.code .vi { color: #ef6155 } /* Name.Variable.Instance */
+.highlight pre .il, pre.code .il { color: #f99b15 } /* Literal.Number.Integer.Long */

--- a/pelican-bootstrap3/static/css/pygments/paraiso-light.css
+++ b/pelican-bootstrap3/static/css/pygments/paraiso-light.css
@@ -1,66 +1,66 @@
-.highlight pre .hll { background-color: #a39e9b }
-.highlight pre  { background: #e7e9db; color: #2f1e2e }
-.highlight pre .c { color: #8d8687 } /* Comment */
-.highlight pre .err { color: #ef6155 } /* Error */
-.highlight pre .k { color: #815ba4 } /* Keyword */
-.highlight pre .l { color: #f99b15 } /* Literal */
-.highlight pre .n { color: #2f1e2e } /* Name */
-.highlight pre .o { color: #5bc4bf } /* Operator */
-.highlight pre .p { color: #2f1e2e } /* Punctuation */
-.highlight pre .cm { color: #8d8687 } /* Comment.Multiline */
-.highlight pre .cp { color: #8d8687 } /* Comment.Preproc */
-.highlight pre .c1 { color: #8d8687 } /* Comment.Single */
-.highlight pre .cs { color: #8d8687 } /* Comment.Special */
-.highlight pre .gd { color: #ef6155 } /* Generic.Deleted */
-.highlight pre .ge { font-style: italic } /* Generic.Emph */
-.highlight pre .gh { color: #2f1e2e; font-weight: bold } /* Generic.Heading */
-.highlight pre .gi { color: #48b685 } /* Generic.Inserted */
-.highlight pre .gp { color: #8d8687; font-weight: bold } /* Generic.Prompt */
-.highlight pre .gs { font-weight: bold } /* Generic.Strong */
-.highlight pre .gu { color: #5bc4bf; font-weight: bold } /* Generic.Subheading */
-.highlight pre .kc { color: #815ba4 } /* Keyword.Constant */
-.highlight pre .kd { color: #815ba4 } /* Keyword.Declaration */
-.highlight pre .kn { color: #5bc4bf } /* Keyword.Namespace */
-.highlight pre .kp { color: #815ba4 } /* Keyword.Pseudo */
-.highlight pre .kr { color: #815ba4 } /* Keyword.Reserved */
-.highlight pre .kt { color: #fec418 } /* Keyword.Type */
-.highlight pre .ld { color: #48b685 } /* Literal.Date */
-.highlight pre .m { color: #f99b15 } /* Literal.Number */
-.highlight pre .s { color: #48b685 } /* Literal.String */
-.highlight pre .na { color: #06b6ef } /* Name.Attribute */
-.highlight pre .nb { color: #2f1e2e } /* Name.Builtin */
-.highlight pre .nc { color: #fec418 } /* Name.Class */
-.highlight pre .no { color: #ef6155 } /* Name.Constant */
-.highlight pre .nd { color: #5bc4bf } /* Name.Decorator */
-.highlight pre .ni { color: #2f1e2e } /* Name.Entity */
-.highlight pre .ne { color: #ef6155 } /* Name.Exception */
-.highlight pre .nf { color: #06b6ef } /* Name.Function */
-.highlight pre .nl { color: #2f1e2e } /* Name.Label */
-.highlight pre .nn { color: #fec418 } /* Name.Namespace */
-.highlight pre .nx { color: #06b6ef } /* Name.Other */
-.highlight pre .py { color: #2f1e2e } /* Name.Property */
-.highlight pre .nt { color: #5bc4bf } /* Name.Tag */
-.highlight pre .nv { color: #ef6155 } /* Name.Variable */
-.highlight pre .ow { color: #5bc4bf } /* Operator.Word */
-.highlight pre .w { color: #2f1e2e } /* Text.Whitespace */
-.highlight pre .mb { color: #f99b15 } /* Literal.Number.Bin */
-.highlight pre .mf { color: #f99b15 } /* Literal.Number.Float */
-.highlight pre .mh { color: #f99b15 } /* Literal.Number.Hex */
-.highlight pre .mi { color: #f99b15 } /* Literal.Number.Integer */
-.highlight pre .mo { color: #f99b15 } /* Literal.Number.Oct */
-.highlight pre .sb { color: #48b685 } /* Literal.String.Backtick */
-.highlight pre .sc { color: #2f1e2e } /* Literal.String.Char */
-.highlight pre .sd { color: #8d8687 } /* Literal.String.Doc */
-.highlight pre .s2 { color: #48b685 } /* Literal.String.Double */
-.highlight pre .se { color: #f99b15 } /* Literal.String.Escape */
-.highlight pre .sh { color: #48b685 } /* Literal.String.Heredoc */
-.highlight pre .si { color: #f99b15 } /* Literal.String.Interpol */
-.highlight pre .sx { color: #48b685 } /* Literal.String.Other */
-.highlight pre .sr { color: #48b685 } /* Literal.String.Regex */
-.highlight pre .s1 { color: #48b685 } /* Literal.String.Single */
-.highlight pre .ss { color: #48b685 } /* Literal.String.Symbol */
-.highlight pre .bp { color: #2f1e2e } /* Name.Builtin.Pseudo */
-.highlight pre .vc { color: #ef6155 } /* Name.Variable.Class */
-.highlight pre .vg { color: #ef6155 } /* Name.Variable.Global */
-.highlight pre .vi { color: #ef6155 } /* Name.Variable.Instance */
-.highlight pre .il { color: #f99b15 } /* Literal.Number.Integer.Long */
+.highlight pre .hll, pre.code .hll { background-color: #a39e9b }
+.highlight pre, pre.code { background: #e7e9db; color: #2f1e2e }
+.highlight pre .c, pre.code .c { color: #8d8687 } /* Comment */
+.highlight pre .err, pre.code .err { color: #ef6155 } /* Error */
+.highlight pre .k, pre.code .k { color: #815ba4 } /* Keyword */
+.highlight pre .l, pre.code .l { color: #f99b15 } /* Literal */
+.highlight pre .n, pre.code .n { color: #2f1e2e } /* Name */
+.highlight pre .o, pre.code .o { color: #5bc4bf } /* Operator */
+.highlight pre .p, pre.code .p { color: #2f1e2e } /* Punctuation */
+.highlight pre .cm, pre.code .cm { color: #8d8687 } /* Comment.Multiline */
+.highlight pre .cp, pre.code .cp { color: #8d8687 } /* Comment.Preproc */
+.highlight pre .c, pre.code .c1 { color: #8d8687 } /* Comment.Single */
+.highlight pre .cs, pre.code .cs { color: #8d8687 } /* Comment.Special */
+.highlight pre .gd, pre.code .gd { color: #ef6155 } /* Generic.Deleted */
+.highlight pre .ge, pre.code .ge { font-style: italic } /* Generic.Emph */
+.highlight pre .gh, pre.code .gh { color: #2f1e2e; font-weight: bold } /* Generic.Heading */
+.highlight pre .gi, pre.code .gi { color: #48b685 } /* Generic.Inserted */
+.highlight pre .gp, pre.code .gp { color: #8d8687; font-weight: bold } /* Generic.Prompt */
+.highlight pre .gs, pre.code .gs { font-weight: bold } /* Generic.Strong */
+.highlight pre .gu, pre.code .gu { color: #5bc4bf; font-weight: bold } /* Generic.Subheading */
+.highlight pre .kc, pre.code .kc { color: #815ba4 } /* Keyword.Constant */
+.highlight pre .kd, pre.code .kd { color: #815ba4 } /* Keyword.Declaration */
+.highlight pre .kn, pre.code .kn { color: #5bc4bf } /* Keyword.Namespace */
+.highlight pre .kp, pre.code .kp { color: #815ba4 } /* Keyword.Pseudo */
+.highlight pre .kr, pre.code .kr { color: #815ba4 } /* Keyword.Reserved */
+.highlight pre .kt, pre.code .kt { color: #fec418 } /* Keyword.Type */
+.highlight pre .ld, pre.code .ld { color: #48b685 } /* Literal.Date */
+.highlight pre .m, pre.code .m { color: #f99b15 } /* Literal.Number */
+.highlight pre .s, pre.code .s { color: #48b685 } /* Literal.String */
+.highlight pre .na, pre.code .na { color: #06b6ef } /* Name.Attribute */
+.highlight pre .nb, pre.code .nb { color: #2f1e2e } /* Name.Builtin */
+.highlight pre .nc, pre.code .nc { color: #fec418 } /* Name.Class */
+.highlight pre .no, pre.code .no { color: #ef6155 } /* Name.Constant */
+.highlight pre .nd, pre.code .nd { color: #5bc4bf } /* Name.Decorator */
+.highlight pre .ni, pre.code .ni { color: #2f1e2e } /* Name.Entity */
+.highlight pre .ne, pre.code .ne { color: #ef6155 } /* Name.Exception */
+.highlight pre .nf, pre.code .nf { color: #06b6ef } /* Name.Function */
+.highlight pre .nl, pre.code .nl { color: #2f1e2e } /* Name.Label */
+.highlight pre .nn, pre.code .nn { color: #fec418 } /* Name.Namespace */
+.highlight pre .nx, pre.code .nx { color: #06b6ef } /* Name.Other */
+.highlight pre .py, pre.code .py { color: #2f1e2e } /* Name.Property */
+.highlight pre .nt, pre.code .nt { color: #5bc4bf } /* Name.Tag */
+.highlight pre .nv, pre.code .nv { color: #ef6155 } /* Name.Variable */
+.highlight pre .ow, pre.code .ow { color: #5bc4bf } /* Operator.Word */
+.highlight pre .w, pre.code .w { color: #2f1e2e } /* Text.Whitespace */
+.highlight pre .mb, pre.code .mb { color: #f99b15 } /* Literal.Number.Bin */
+.highlight pre .mf, pre.code .mf { color: #f99b15 } /* Literal.Number.Float */
+.highlight pre .mh, pre.code .mh { color: #f99b15 } /* Literal.Number.Hex */
+.highlight pre .mi, pre.code .mi { color: #f99b15 } /* Literal.Number.Integer */
+.highlight pre .mo, pre.code .mo { color: #f99b15 } /* Literal.Number.Oct */
+.highlight pre .sb, pre.code .sb { color: #48b685 } /* Literal.String.Backtick */
+.highlight pre .sc, pre.code .sc { color: #2f1e2e } /* Literal.String.Char */
+.highlight pre .sd, pre.code .sd { color: #8d8687 } /* Literal.String.Doc */
+.highlight pre .s, pre.code .s2 { color: #48b685 } /* Literal.String.Double */
+.highlight pre .se, pre.code .se { color: #f99b15 } /* Literal.String.Escape */
+.highlight pre .sh, pre.code .sh { color: #48b685 } /* Literal.String.Heredoc */
+.highlight pre .si, pre.code .si { color: #f99b15 } /* Literal.String.Interpol */
+.highlight pre .sx, pre.code .sx { color: #48b685 } /* Literal.String.Other */
+.highlight pre .sr, pre.code .sr { color: #48b685 } /* Literal.String.Regex */
+.highlight pre .s, pre.code .s1 { color: #48b685 } /* Literal.String.Single */
+.highlight pre .ss, pre.code .ss { color: #48b685 } /* Literal.String.Symbol */
+.highlight pre .bp, pre.code .bp { color: #2f1e2e } /* Name.Builtin.Pseudo */
+.highlight pre .vc, pre.code .vc { color: #ef6155 } /* Name.Variable.Class */
+.highlight pre .vg, pre.code .vg { color: #ef6155 } /* Name.Variable.Global */
+.highlight pre .vi, pre.code .vi { color: #ef6155 } /* Name.Variable.Instance */
+.highlight pre .il, pre.code .il { color: #f99b15 } /* Literal.Number.Integer.Long */

--- a/pelican-bootstrap3/static/css/pygments/pastie.css
+++ b/pelican-bootstrap3/static/css/pygments/pastie.css
@@ -1,62 +1,62 @@
-.highlight pre .hll { background-color: #ffffcc }
-.highlight pre  { background: #ffffff; }
-.highlight pre .c { color: #888888 } /* Comment */
-.highlight pre .err { color: #a61717; background-color: #e3d2d2 } /* Error */
-.highlight pre .k { color: #008800; font-weight: bold } /* Keyword */
-.highlight pre .cm { color: #888888 } /* Comment.Multiline */
-.highlight pre .cp { color: #cc0000; font-weight: bold } /* Comment.Preproc */
-.highlight pre .c1 { color: #888888 } /* Comment.Single */
-.highlight pre .cs { color: #cc0000; font-weight: bold; background-color: #fff0f0 } /* Comment.Special */
-.highlight pre .gd { color: #000000; background-color: #ffdddd } /* Generic.Deleted */
-.highlight pre .ge { font-style: italic } /* Generic.Emph */
-.highlight pre .gr { color: #aa0000 } /* Generic.Error */
-.highlight pre .gh { color: #333333 } /* Generic.Heading */
-.highlight pre .gi { color: #000000; background-color: #ddffdd } /* Generic.Inserted */
-.highlight pre .go { color: #888888 } /* Generic.Output */
-.highlight pre .gp { color: #555555 } /* Generic.Prompt */
-.highlight pre .gs { font-weight: bold } /* Generic.Strong */
-.highlight pre .gu { color: #666666 } /* Generic.Subheading */
-.highlight pre .gt { color: #aa0000 } /* Generic.Traceback */
-.highlight pre .kc { color: #008800; font-weight: bold } /* Keyword.Constant */
-.highlight pre .kd { color: #008800; font-weight: bold } /* Keyword.Declaration */
-.highlight pre .kn { color: #008800; font-weight: bold } /* Keyword.Namespace */
-.highlight pre .kp { color: #008800 } /* Keyword.Pseudo */
-.highlight pre .kr { color: #008800; font-weight: bold } /* Keyword.Reserved */
-.highlight pre .kt { color: #888888; font-weight: bold } /* Keyword.Type */
-.highlight pre .m { color: #0000DD; font-weight: bold } /* Literal.Number */
-.highlight pre .s { color: #dd2200; background-color: #fff0f0 } /* Literal.String */
-.highlight pre .na { color: #336699 } /* Name.Attribute */
-.highlight pre .nb { color: #003388 } /* Name.Builtin */
-.highlight pre .nc { color: #bb0066; font-weight: bold } /* Name.Class */
-.highlight pre .no { color: #003366; font-weight: bold } /* Name.Constant */
-.highlight pre .nd { color: #555555 } /* Name.Decorator */
-.highlight pre .ne { color: #bb0066; font-weight: bold } /* Name.Exception */
-.highlight pre .nf { color: #0066bb; font-weight: bold } /* Name.Function */
-.highlight pre .nl { color: #336699; font-style: italic } /* Name.Label */
-.highlight pre .nn { color: #bb0066; font-weight: bold } /* Name.Namespace */
-.highlight pre .py { color: #336699; font-weight: bold } /* Name.Property */
-.highlight pre .nt { color: #bb0066; font-weight: bold } /* Name.Tag */
-.highlight pre .nv { color: #336699 } /* Name.Variable */
-.highlight pre .ow { color: #008800 } /* Operator.Word */
-.highlight pre .w { color: #bbbbbb } /* Text.Whitespace */
-.highlight pre .mb { color: #0000DD; font-weight: bold } /* Literal.Number.Bin */
-.highlight pre .mf { color: #0000DD; font-weight: bold } /* Literal.Number.Float */
-.highlight pre .mh { color: #0000DD; font-weight: bold } /* Literal.Number.Hex */
-.highlight pre .mi { color: #0000DD; font-weight: bold } /* Literal.Number.Integer */
-.highlight pre .mo { color: #0000DD; font-weight: bold } /* Literal.Number.Oct */
-.highlight pre .sb { color: #dd2200; background-color: #fff0f0 } /* Literal.String.Backtick */
-.highlight pre .sc { color: #dd2200; background-color: #fff0f0 } /* Literal.String.Char */
-.highlight pre .sd { color: #dd2200; background-color: #fff0f0 } /* Literal.String.Doc */
-.highlight pre .s2 { color: #dd2200; background-color: #fff0f0 } /* Literal.String.Double */
-.highlight pre .se { color: #0044dd; background-color: #fff0f0 } /* Literal.String.Escape */
-.highlight pre .sh { color: #dd2200; background-color: #fff0f0 } /* Literal.String.Heredoc */
-.highlight pre .si { color: #3333bb; background-color: #fff0f0 } /* Literal.String.Interpol */
-.highlight pre .sx { color: #22bb22; background-color: #f0fff0 } /* Literal.String.Other */
-.highlight pre .sr { color: #008800; background-color: #fff0ff } /* Literal.String.Regex */
-.highlight pre .s1 { color: #dd2200; background-color: #fff0f0 } /* Literal.String.Single */
-.highlight pre .ss { color: #aa6600; background-color: #fff0f0 } /* Literal.String.Symbol */
-.highlight pre .bp { color: #003388 } /* Name.Builtin.Pseudo */
-.highlight pre .vc { color: #336699 } /* Name.Variable.Class */
-.highlight pre .vg { color: #dd7700 } /* Name.Variable.Global */
-.highlight pre .vi { color: #3333bb } /* Name.Variable.Instance */
-.highlight pre .il { color: #0000DD; font-weight: bold } /* Literal.Number.Integer.Long */
+.highlight pre .hll, pre.code .hll { background-color: #ffffcc }
+.highlight pre, pre.code { background: #ffffff; }
+.highlight pre .c, pre.code .c { color: #888888 } /* Comment */
+.highlight pre .err, pre.code .err { color: #a61717; background-color: #e3d2d2 } /* Error */
+.highlight pre .k, pre.code .k { color: #008800; font-weight: bold } /* Keyword */
+.highlight pre .cm, pre.code .cm { color: #888888 } /* Comment.Multiline */
+.highlight pre .cp, pre.code .cp { color: #cc0000; font-weight: bold } /* Comment.Preproc */
+.highlight pre .c, pre.code .c1 { color: #888888 } /* Comment.Single */
+.highlight pre .cs, pre.code .cs { color: #cc0000; font-weight: bold; background-color: #fff0f0 } /* Comment.Special */
+.highlight pre .gd, pre.code .gd { color: #000000; background-color: #ffdddd } /* Generic.Deleted */
+.highlight pre .ge, pre.code .ge { font-style: italic } /* Generic.Emph */
+.highlight pre .gr, pre.code .gr { color: #aa0000 } /* Generic.Error */
+.highlight pre .gh, pre.code .gh { color: #333333 } /* Generic.Heading */
+.highlight pre .gi, pre.code .gi { color: #000000; background-color: #ddffdd } /* Generic.Inserted */
+.highlight pre .go, pre.code .go { color: #888888 } /* Generic.Output */
+.highlight pre .gp, pre.code .gp { color: #555555 } /* Generic.Prompt */
+.highlight pre .gs, pre.code .gs { font-weight: bold } /* Generic.Strong */
+.highlight pre .gu, pre.code .gu { color: #666666 } /* Generic.Subheading */
+.highlight pre .gt, pre.code .gt { color: #aa0000 } /* Generic.Traceback */
+.highlight pre .kc, pre.code .kc { color: #008800; font-weight: bold } /* Keyword.Constant */
+.highlight pre .kd, pre.code .kd { color: #008800; font-weight: bold } /* Keyword.Declaration */
+.highlight pre .kn, pre.code .kn { color: #008800; font-weight: bold } /* Keyword.Namespace */
+.highlight pre .kp, pre.code .kp { color: #008800 } /* Keyword.Pseudo */
+.highlight pre .kr, pre.code .kr { color: #008800; font-weight: bold } /* Keyword.Reserved */
+.highlight pre .kt, pre.code .kt { color: #888888; font-weight: bold } /* Keyword.Type */
+.highlight pre .m, pre.code .m { color: #0000DD; font-weight: bold } /* Literal.Number */
+.highlight pre .s, pre.code .s { color: #dd2200; background-color: #fff0f0 } /* Literal.String */
+.highlight pre .na, pre.code .na { color: #336699 } /* Name.Attribute */
+.highlight pre .nb, pre.code .nb { color: #003388 } /* Name.Builtin */
+.highlight pre .nc, pre.code .nc { color: #bb0066; font-weight: bold } /* Name.Class */
+.highlight pre .no, pre.code .no { color: #003366; font-weight: bold } /* Name.Constant */
+.highlight pre .nd, pre.code .nd { color: #555555 } /* Name.Decorator */
+.highlight pre .ne, pre.code .ne { color: #bb0066; font-weight: bold } /* Name.Exception */
+.highlight pre .nf, pre.code .nf { color: #0066bb; font-weight: bold } /* Name.Function */
+.highlight pre .nl, pre.code .nl { color: #336699; font-style: italic } /* Name.Label */
+.highlight pre .nn, pre.code .nn { color: #bb0066; font-weight: bold } /* Name.Namespace */
+.highlight pre .py, pre.code .py { color: #336699; font-weight: bold } /* Name.Property */
+.highlight pre .nt, pre.code .nt { color: #bb0066; font-weight: bold } /* Name.Tag */
+.highlight pre .nv, pre.code .nv { color: #336699 } /* Name.Variable */
+.highlight pre .ow, pre.code .ow { color: #008800 } /* Operator.Word */
+.highlight pre .w, pre.code .w { color: #bbbbbb } /* Text.Whitespace */
+.highlight pre .mb, pre.code .mb { color: #0000DD; font-weight: bold } /* Literal.Number.Bin */
+.highlight pre .mf, pre.code .mf { color: #0000DD; font-weight: bold } /* Literal.Number.Float */
+.highlight pre .mh, pre.code .mh { color: #0000DD; font-weight: bold } /* Literal.Number.Hex */
+.highlight pre .mi, pre.code .mi { color: #0000DD; font-weight: bold } /* Literal.Number.Integer */
+.highlight pre .mo, pre.code .mo { color: #0000DD; font-weight: bold } /* Literal.Number.Oct */
+.highlight pre .sb, pre.code .sb { color: #dd2200; background-color: #fff0f0 } /* Literal.String.Backtick */
+.highlight pre .sc, pre.code .sc { color: #dd2200; background-color: #fff0f0 } /* Literal.String.Char */
+.highlight pre .sd, pre.code .sd { color: #dd2200; background-color: #fff0f0 } /* Literal.String.Doc */
+.highlight pre .s, pre.code .s2 { color: #dd2200; background-color: #fff0f0 } /* Literal.String.Double */
+.highlight pre .se, pre.code .se { color: #0044dd; background-color: #fff0f0 } /* Literal.String.Escape */
+.highlight pre .sh, pre.code .sh { color: #dd2200; background-color: #fff0f0 } /* Literal.String.Heredoc */
+.highlight pre .si, pre.code .si { color: #3333bb; background-color: #fff0f0 } /* Literal.String.Interpol */
+.highlight pre .sx, pre.code .sx { color: #22bb22; background-color: #f0fff0 } /* Literal.String.Other */
+.highlight pre .sr, pre.code .sr { color: #008800; background-color: #fff0ff } /* Literal.String.Regex */
+.highlight pre .s, pre.code .s1 { color: #dd2200; background-color: #fff0f0 } /* Literal.String.Single */
+.highlight pre .ss, pre.code .ss { color: #aa6600; background-color: #fff0f0 } /* Literal.String.Symbol */
+.highlight pre .bp, pre.code .bp { color: #003388 } /* Name.Builtin.Pseudo */
+.highlight pre .vc, pre.code .vc { color: #336699 } /* Name.Variable.Class */
+.highlight pre .vg, pre.code .vg { color: #dd7700 } /* Name.Variable.Global */
+.highlight pre .vi, pre.code .vi { color: #3333bb } /* Name.Variable.Instance */
+.highlight pre .il, pre.code .il { color: #0000DD; font-weight: bold } /* Literal.Number.Integer.Long */

--- a/pelican-bootstrap3/static/css/pygments/perldoc.css
+++ b/pelican-bootstrap3/static/css/pygments/perldoc.css
@@ -1,60 +1,60 @@
-.highlight pre .hll { background-color: #ffffcc }
-.highlight pre  { background: #eeeedd; }
-.highlight pre .c { color: #228B22 } /* Comment */
-.highlight pre .err { color: #a61717; background-color: #e3d2d2 } /* Error */
-.highlight pre .k { color: #8B008B; font-weight: bold } /* Keyword */
-.highlight pre .cm { color: #228B22 } /* Comment.Multiline */
-.highlight pre .cp { color: #1e889b } /* Comment.Preproc */
-.highlight pre .c1 { color: #228B22 } /* Comment.Single */
-.highlight pre .cs { color: #8B008B; font-weight: bold } /* Comment.Special */
-.highlight pre .gd { color: #aa0000 } /* Generic.Deleted */
-.highlight pre .ge { font-style: italic } /* Generic.Emph */
-.highlight pre .gr { color: #aa0000 } /* Generic.Error */
-.highlight pre .gh { color: #000080; font-weight: bold } /* Generic.Heading */
-.highlight pre .gi { color: #00aa00 } /* Generic.Inserted */
-.highlight pre .go { color: #888888 } /* Generic.Output */
-.highlight pre .gp { color: #555555 } /* Generic.Prompt */
-.highlight pre .gs { font-weight: bold } /* Generic.Strong */
-.highlight pre .gu { color: #800080; font-weight: bold } /* Generic.Subheading */
-.highlight pre .gt { color: #aa0000 } /* Generic.Traceback */
-.highlight pre .kc { color: #8B008B; font-weight: bold } /* Keyword.Constant */
-.highlight pre .kd { color: #8B008B; font-weight: bold } /* Keyword.Declaration */
-.highlight pre .kn { color: #8B008B; font-weight: bold } /* Keyword.Namespace */
-.highlight pre .kp { color: #8B008B; font-weight: bold } /* Keyword.Pseudo */
-.highlight pre .kr { color: #8B008B; font-weight: bold } /* Keyword.Reserved */
-.highlight pre .kt { color: #a7a7a7; font-weight: bold } /* Keyword.Type */
-.highlight pre .m { color: #B452CD } /* Literal.Number */
-.highlight pre .s { color: #CD5555 } /* Literal.String */
-.highlight pre .na { color: #658b00 } /* Name.Attribute */
-.highlight pre .nb { color: #658b00 } /* Name.Builtin */
-.highlight pre .nc { color: #008b45; font-weight: bold } /* Name.Class */
-.highlight pre .no { color: #00688B } /* Name.Constant */
-.highlight pre .nd { color: #707a7c } /* Name.Decorator */
-.highlight pre .ne { color: #008b45; font-weight: bold } /* Name.Exception */
-.highlight pre .nf { color: #008b45 } /* Name.Function */
-.highlight pre .nn { color: #008b45; text-decoration: underline } /* Name.Namespace */
-.highlight pre .nt { color: #8B008B; font-weight: bold } /* Name.Tag */
-.highlight pre .nv { color: #00688B } /* Name.Variable */
-.highlight pre .ow { color: #8B008B } /* Operator.Word */
-.highlight pre .w { color: #bbbbbb } /* Text.Whitespace */
-.highlight pre .mb { color: #B452CD } /* Literal.Number.Bin */
-.highlight pre .mf { color: #B452CD } /* Literal.Number.Float */
-.highlight pre .mh { color: #B452CD } /* Literal.Number.Hex */
-.highlight pre .mi { color: #B452CD } /* Literal.Number.Integer */
-.highlight pre .mo { color: #B452CD } /* Literal.Number.Oct */
-.highlight pre .sb { color: #CD5555 } /* Literal.String.Backtick */
-.highlight pre .sc { color: #CD5555 } /* Literal.String.Char */
-.highlight pre .sd { color: #CD5555 } /* Literal.String.Doc */
-.highlight pre .s2 { color: #CD5555 } /* Literal.String.Double */
-.highlight pre .se { color: #CD5555 } /* Literal.String.Escape */
-.highlight pre .sh { color: #1c7e71; font-style: italic } /* Literal.String.Heredoc */
-.highlight pre .si { color: #CD5555 } /* Literal.String.Interpol */
-.highlight pre .sx { color: #cb6c20 } /* Literal.String.Other */
-.highlight pre .sr { color: #1c7e71 } /* Literal.String.Regex */
-.highlight pre .s1 { color: #CD5555 } /* Literal.String.Single */
-.highlight pre .ss { color: #CD5555 } /* Literal.String.Symbol */
-.highlight pre .bp { color: #658b00 } /* Name.Builtin.Pseudo */
-.highlight pre .vc { color: #00688B } /* Name.Variable.Class */
-.highlight pre .vg { color: #00688B } /* Name.Variable.Global */
-.highlight pre .vi { color: #00688B } /* Name.Variable.Instance */
-.highlight pre .il { color: #B452CD } /* Literal.Number.Integer.Long */
+.highlight pre .hll, pre.code .hll { background-color: #ffffcc }
+.highlight pre, pre.code { background: #eeeedd; }
+.highlight pre .c, pre.code .c { color: #228B22 } /* Comment */
+.highlight pre .err, pre.code .err { color: #a61717; background-color: #e3d2d2 } /* Error */
+.highlight pre .k, pre.code .k { color: #8B008B; font-weight: bold } /* Keyword */
+.highlight pre .cm, pre.code .cm { color: #228B22 } /* Comment.Multiline */
+.highlight pre .cp, pre.code .cp { color: #1e889b } /* Comment.Preproc */
+.highlight pre .c, pre.code .c1 { color: #228B22 } /* Comment.Single */
+.highlight pre .cs, pre.code .cs { color: #8B008B; font-weight: bold } /* Comment.Special */
+.highlight pre .gd, pre.code .gd { color: #aa0000 } /* Generic.Deleted */
+.highlight pre .ge, pre.code .ge { font-style: italic } /* Generic.Emph */
+.highlight pre .gr, pre.code .gr { color: #aa0000 } /* Generic.Error */
+.highlight pre .gh, pre.code .gh { color: #000080; font-weight: bold } /* Generic.Heading */
+.highlight pre .gi, pre.code .gi { color: #00aa00 } /* Generic.Inserted */
+.highlight pre .go, pre.code .go { color: #888888 } /* Generic.Output */
+.highlight pre .gp, pre.code .gp { color: #555555 } /* Generic.Prompt */
+.highlight pre .gs, pre.code .gs { font-weight: bold } /* Generic.Strong */
+.highlight pre .gu, pre.code .gu { color: #800080; font-weight: bold } /* Generic.Subheading */
+.highlight pre .gt, pre.code .gt { color: #aa0000 } /* Generic.Traceback */
+.highlight pre .kc, pre.code .kc { color: #8B008B; font-weight: bold } /* Keyword.Constant */
+.highlight pre .kd, pre.code .kd { color: #8B008B; font-weight: bold } /* Keyword.Declaration */
+.highlight pre .kn, pre.code .kn { color: #8B008B; font-weight: bold } /* Keyword.Namespace */
+.highlight pre .kp, pre.code .kp { color: #8B008B; font-weight: bold } /* Keyword.Pseudo */
+.highlight pre .kr, pre.code .kr { color: #8B008B; font-weight: bold } /* Keyword.Reserved */
+.highlight pre .kt, pre.code .kt { color: #a7a7a7; font-weight: bold } /* Keyword.Type */
+.highlight pre .m, pre.code .m { color: #B452CD } /* Literal.Number */
+.highlight pre .s, pre.code .s { color: #CD5555 } /* Literal.String */
+.highlight pre .na, pre.code .na { color: #658b00 } /* Name.Attribute */
+.highlight pre .nb, pre.code .nb { color: #658b00 } /* Name.Builtin */
+.highlight pre .nc, pre.code .nc { color: #008b45; font-weight: bold } /* Name.Class */
+.highlight pre .no, pre.code .no { color: #00688B } /* Name.Constant */
+.highlight pre .nd, pre.code .nd { color: #707a7c } /* Name.Decorator */
+.highlight pre .ne, pre.code .ne { color: #008b45; font-weight: bold } /* Name.Exception */
+.highlight pre .nf, pre.code .nf { color: #008b45 } /* Name.Function */
+.highlight pre .nn, pre.code .nn { color: #008b45; text-decoration: underline } /* Name.Namespace */
+.highlight pre .nt, pre.code .nt { color: #8B008B; font-weight: bold } /* Name.Tag */
+.highlight pre .nv, pre.code .nv { color: #00688B } /* Name.Variable */
+.highlight pre .ow, pre.code .ow { color: #8B008B } /* Operator.Word */
+.highlight pre .w, pre.code .w { color: #bbbbbb } /* Text.Whitespace */
+.highlight pre .mb, pre.code .mb { color: #B452CD } /* Literal.Number.Bin */
+.highlight pre .mf, pre.code .mf { color: #B452CD } /* Literal.Number.Float */
+.highlight pre .mh, pre.code .mh { color: #B452CD } /* Literal.Number.Hex */
+.highlight pre .mi, pre.code .mi { color: #B452CD } /* Literal.Number.Integer */
+.highlight pre .mo, pre.code .mo { color: #B452CD } /* Literal.Number.Oct */
+.highlight pre .sb, pre.code .sb { color: #CD5555 } /* Literal.String.Backtick */
+.highlight pre .sc, pre.code .sc { color: #CD5555 } /* Literal.String.Char */
+.highlight pre .sd, pre.code .sd { color: #CD5555 } /* Literal.String.Doc */
+.highlight pre .s, pre.code .s2 { color: #CD5555 } /* Literal.String.Double */
+.highlight pre .se, pre.code .se { color: #CD5555 } /* Literal.String.Escape */
+.highlight pre .sh, pre.code .sh { color: #1c7e71; font-style: italic } /* Literal.String.Heredoc */
+.highlight pre .si, pre.code .si { color: #CD5555 } /* Literal.String.Interpol */
+.highlight pre .sx, pre.code .sx { color: #cb6c20 } /* Literal.String.Other */
+.highlight pre .sr, pre.code .sr { color: #1c7e71 } /* Literal.String.Regex */
+.highlight pre .s, pre.code .s1 { color: #CD5555 } /* Literal.String.Single */
+.highlight pre .ss, pre.code .ss { color: #CD5555 } /* Literal.String.Symbol */
+.highlight pre .bp, pre.code .bp { color: #658b00 } /* Name.Builtin.Pseudo */
+.highlight pre .vc, pre.code .vc { color: #00688B } /* Name.Variable.Class */
+.highlight pre .vg, pre.code .vg { color: #00688B } /* Name.Variable.Global */
+.highlight pre .vi, pre.code .vi { color: #00688B } /* Name.Variable.Instance */
+.highlight pre .il, pre.code .il { color: #B452CD } /* Literal.Number.Integer.Long */

--- a/pelican-bootstrap3/static/css/pygments/rrt.css
+++ b/pelican-bootstrap3/static/css/pygments/rrt.css
@@ -1,32 +1,32 @@
-.highlight pre .hll { background-color: #0000ff }
-.highlight pre  { background: #000000; }
-.highlight pre .c { color: #00ff00 } /* Comment */
-.highlight pre .k { color: #ff0000 } /* Keyword */
-.highlight pre .cm { color: #00ff00 } /* Comment.Multiline */
-.highlight pre .cp { color: #e5e5e5 } /* Comment.Preproc */
-.highlight pre .c1 { color: #00ff00 } /* Comment.Single */
-.highlight pre .cs { color: #00ff00 } /* Comment.Special */
-.highlight pre .kc { color: #ff0000 } /* Keyword.Constant */
-.highlight pre .kd { color: #ff0000 } /* Keyword.Declaration */
-.highlight pre .kn { color: #ff0000 } /* Keyword.Namespace */
-.highlight pre .kp { color: #ff0000 } /* Keyword.Pseudo */
-.highlight pre .kr { color: #ff0000 } /* Keyword.Reserved */
-.highlight pre .kt { color: #ee82ee } /* Keyword.Type */
-.highlight pre .s { color: #87ceeb } /* Literal.String */
-.highlight pre .no { color: #7fffd4 } /* Name.Constant */
-.highlight pre .nf { color: #ffff00 } /* Name.Function */
-.highlight pre .nv { color: #eedd82 } /* Name.Variable */
-.highlight pre .sb { color: #87ceeb } /* Literal.String.Backtick */
-.highlight pre .sc { color: #87ceeb } /* Literal.String.Char */
-.highlight pre .sd { color: #87ceeb } /* Literal.String.Doc */
-.highlight pre .s2 { color: #87ceeb } /* Literal.String.Double */
-.highlight pre .se { color: #87ceeb } /* Literal.String.Escape */
-.highlight pre .sh { color: #87ceeb } /* Literal.String.Heredoc */
-.highlight pre .si { color: #87ceeb } /* Literal.String.Interpol */
-.highlight pre .sx { color: #87ceeb } /* Literal.String.Other */
-.highlight pre .sr { color: #87ceeb } /* Literal.String.Regex */
-.highlight pre .s1 { color: #87ceeb } /* Literal.String.Single */
-.highlight pre .ss { color: #87ceeb } /* Literal.String.Symbol */
-.highlight pre .vc { color: #eedd82 } /* Name.Variable.Class */
-.highlight pre .vg { color: #eedd82 } /* Name.Variable.Global */
-.highlight pre .vi { color: #eedd82 } /* Name.Variable.Instance */
+.highlight pre .hll, pre.code .hll { background-color: #0000ff }
+.highlight pre, pre.code { background: #000000; }
+.highlight pre .c, pre.code .c { color: #00ff00 } /* Comment */
+.highlight pre .k, pre.code .k { color: #ff0000 } /* Keyword */
+.highlight pre .cm, pre.code .cm { color: #00ff00 } /* Comment.Multiline */
+.highlight pre .cp, pre.code .cp { color: #e5e5e5 } /* Comment.Preproc */
+.highlight pre .c, pre.code .c1 { color: #00ff00 } /* Comment.Single */
+.highlight pre .cs, pre.code .cs { color: #00ff00 } /* Comment.Special */
+.highlight pre .kc, pre.code .kc { color: #ff0000 } /* Keyword.Constant */
+.highlight pre .kd, pre.code .kd { color: #ff0000 } /* Keyword.Declaration */
+.highlight pre .kn, pre.code .kn { color: #ff0000 } /* Keyword.Namespace */
+.highlight pre .kp, pre.code .kp { color: #ff0000 } /* Keyword.Pseudo */
+.highlight pre .kr, pre.code .kr { color: #ff0000 } /* Keyword.Reserved */
+.highlight pre .kt, pre.code .kt { color: #ee82ee } /* Keyword.Type */
+.highlight pre .s, pre.code .s { color: #87ceeb } /* Literal.String */
+.highlight pre .no, pre.code .no { color: #7fffd4 } /* Name.Constant */
+.highlight pre .nf, pre.code .nf { color: #ffff00 } /* Name.Function */
+.highlight pre .nv, pre.code .nv { color: #eedd82 } /* Name.Variable */
+.highlight pre .sb, pre.code .sb { color: #87ceeb } /* Literal.String.Backtick */
+.highlight pre .sc, pre.code .sc { color: #87ceeb } /* Literal.String.Char */
+.highlight pre .sd, pre.code .sd { color: #87ceeb } /* Literal.String.Doc */
+.highlight pre .s, pre.code .s2 { color: #87ceeb } /* Literal.String.Double */
+.highlight pre .se, pre.code .se { color: #87ceeb } /* Literal.String.Escape */
+.highlight pre .sh, pre.code .sh { color: #87ceeb } /* Literal.String.Heredoc */
+.highlight pre .si, pre.code .si { color: #87ceeb } /* Literal.String.Interpol */
+.highlight pre .sx, pre.code .sx { color: #87ceeb } /* Literal.String.Other */
+.highlight pre .sr, pre.code .sr { color: #87ceeb } /* Literal.String.Regex */
+.highlight pre .s, pre.code .s1 { color: #87ceeb } /* Literal.String.Single */
+.highlight pre .ss, pre.code .ss { color: #87ceeb } /* Literal.String.Symbol */
+.highlight pre .vc, pre.code .vc { color: #eedd82 } /* Name.Variable.Class */
+.highlight pre .vg, pre.code .vg { color: #eedd82 } /* Name.Variable.Global */
+.highlight pre .vi, pre.code .vi { color: #eedd82 } /* Name.Variable.Instance */

--- a/pelican-bootstrap3/static/css/pygments/solarizeddark.css
+++ b/pelican-bootstrap3/static/css/pygments/solarizeddark.css
@@ -1,70 +1,70 @@
-.highlight pre .hll { background-color: #ffffcc }
-.highlight pre, .highlighttable pre { background: #002b36; color: #839496 }
-.highlight pre .c { color: #586e75; font-style: italic } /* Comment */
-.highlight pre .err { color: #dc322f } /* Error */
-.highlight pre .g { color: #839496 } /* Generic */
-.highlight pre .k { color: #859900 } /* Keyword */
-.highlight pre .l { color: #839496 } /* Literal */
-.highlight pre .n { color: #93a1a1 } /* Name */
-.highlight pre .o { color: #839496 } /* Operator */
-.highlight pre .x { color: #839496 } /* Other */
-.highlight pre .p { color: #839496 } /* Punctuation */
-.highlight pre .cm { color: #586e75; font-style: italic } /* Comment.Multiline */
-.highlight pre .cp { color: #586e75; font-style: italic } /* Comment.Preproc */
-.highlight pre .c1 { color: #586e75; font-style: italic } /* Comment.Single */
-.highlight pre .cs { color: #586e75; font-style: italic } /* Comment.Special */
-.highlight pre .gd { color: #839496 } /* Generic.Deleted */
-.highlight pre .ge { color: #839496 } /* Generic.Emph */
-.highlight pre .gr { color: #839496 } /* Generic.Error */
-.highlight pre .gh { color: #839496 } /* Generic.Heading */
-.highlight pre .gi { color: #839496 } /* Generic.Inserted */
-.highlight pre .go { color: #839496 } /* Generic.Output */
-.highlight pre .gp { color: #839496 } /* Generic.Prompt */
-.highlight pre .gs { color: #839496 } /* Generic.Strong */
-.highlight pre .gu { color: #839496 } /* Generic.Subheading */
-.highlight pre .gt { color: #839496 } /* Generic.Traceback */
-.highlight pre .kc { color: #859900 } /* Keyword.Constant */
-.highlight pre .kd { color: #859900 } /* Keyword.Declaration */
-.highlight pre .kn { color: #cb4b16 } /* Keyword.Namespace */
-.highlight pre .kp { color: #cb4b16 } /* Keyword.Pseudo */
-.highlight pre .kr { color: #859900 } /* Keyword.Reserved */
-.highlight pre .kt { color: #859900 } /* Keyword.Type */
-.highlight pre .ld { color: #839496 } /* Literal.Date */
-.highlight pre .m { color: #2aa198 } /* Literal.Number */
-.highlight pre .s { color: #2aa198 } /* Literal.String */
-.highlight pre .na { color: #839496 } /* Name.Attribute */
-.highlight pre .nb { color: #268bd2 } /* Name.Builtin */
-.highlight pre .nc { color: #268bd2 } /* Name.Class */
-.highlight pre .no { color: #b58900 } /* Name.Constant */
-.highlight pre .nd { color: #cb4b16 } /* Name.Decorator */
-.highlight pre .ni { color: #cb4b16 } /* Name.Entity */
-.highlight pre .ne { color: #cb4b16 } /* Name.Exception */
-.highlight pre .nf { color: #268bd2 } /* Name.Function */
-.highlight pre .nl { color: #839496 } /* Name.Label */
-.highlight pre .nn { color: #b58900 } /* Name.Namespace */
-.highlight pre .nx { color: #839496 } /* Name.Other */
-.highlight pre .py { color: #268bd2 } /* Name.Property */
-.highlight pre .nt { color: #859900 } /* Name.Tag */
-.highlight pre .nv { color: #cb4b16 } /* Name.Variable */
-.highlight pre .ow { color: #859900 } /* Operator.Word */
-.highlight pre .w { color: #002b36 } /* Text.Whitespace */
-.highlight pre .mf { color: #2aa198 } /* Literal.Number.Float */
-.highlight pre .mh { color: #2aa198 } /* Literal.Number.Hex */
-.highlight pre .mi { color: #2aa198 } /* Literal.Number.Integer */
-.highlight pre .mo { color: #2aa198 } /* Literal.Number.Oct */
-.highlight pre .sb { color: #2aa198 } /* Literal.String.Backtick */
-.highlight pre .sc { color: #2aa198 } /* Literal.String.Char */
-.highlight pre .sd { color: #2aa198 } /* Literal.String.Doc */
-.highlight pre .s2 { color: #2aa198 } /* Literal.String.Double */
-.highlight pre .se { color: #cb4b16 } /* Literal.String.Escape */
-.highlight pre .sh { color: #2aa198 } /* Literal.String.Heredoc */
-.highlight pre .si { color: #cb4b16 } /* Literal.String.Interpol */
-.highlight pre .sx { color: #2aa198 } /* Literal.String.Other */
-.highlight pre .sr { color: #2aa198 } /* Literal.String.Regex */
-.highlight pre .s1 { color: #2aa198 } /* Literal.String.Single */
-.highlight pre .ss { color: #2aa198 } /* Literal.String.Symbol */
-.highlight pre .bp { color: #268bd2; font-weight: bold } /* Name.Builtin.Pseudo */
-.highlight pre .vc { color: #268bd2 } /* Name.Variable.Class */
-.highlight pre .vg { color: #268bd2 } /* Name.Variable.Global */
-.highlight pre .vi { color: #268bd2 } /* Name.Variable.Instance */
-.highlight pre .il { color: #2aa198 } /* Literal.Number.Integer.Long */
+.highlight pre .hll, pre.code .hll { background-color: #ffffcc }
+.highlight pre, pre.code, .highlighttable pre { background: #002b36; color: #839496 }
+.highlight pre .c, pre.code .c { color: #586e75; font-style: italic } /* Comment */
+.highlight pre .err, pre.code .err { color: #dc322f } /* Error */
+.highlight pre .g, pre.code .g { color: #839496 } /* Generic */
+.highlight pre .k, pre.code .k { color: #859900 } /* Keyword */
+.highlight pre .l, pre.code .l { color: #839496 } /* Literal */
+.highlight pre .n, pre.code .n { color: #93a1a1 } /* Name */
+.highlight pre .o, pre.code .o { color: #839496 } /* Operator */
+.highlight pre .x, pre.code .x { color: #839496 } /* Other */
+.highlight pre .p, pre.code .p { color: #839496 } /* Punctuation */
+.highlight pre .cm, pre.code .cm { color: #586e75; font-style: italic } /* Comment.Multiline */
+.highlight pre .cp, pre.code .cp { color: #586e75; font-style: italic } /* Comment.Preproc */
+.highlight pre .c, pre.code .c1 { color: #586e75; font-style: italic } /* Comment.Single */
+.highlight pre .cs, pre.code .cs { color: #586e75; font-style: italic } /* Comment.Special */
+.highlight pre .gd, pre.code .gd { color: #839496 } /* Generic.Deleted */
+.highlight pre .ge, pre.code .ge { color: #839496 } /* Generic.Emph */
+.highlight pre .gr, pre.code .gr { color: #839496 } /* Generic.Error */
+.highlight pre .gh, pre.code .gh { color: #839496 } /* Generic.Heading */
+.highlight pre .gi, pre.code .gi { color: #839496 } /* Generic.Inserted */
+.highlight pre .go, pre.code .go { color: #839496 } /* Generic.Output */
+.highlight pre .gp, pre.code .gp { color: #839496 } /* Generic.Prompt */
+.highlight pre .gs, pre.code .gs { color: #839496 } /* Generic.Strong */
+.highlight pre .gu, pre.code .gu { color: #839496 } /* Generic.Subheading */
+.highlight pre .gt, pre.code .gt { color: #839496 } /* Generic.Traceback */
+.highlight pre .kc, pre.code .kc { color: #859900 } /* Keyword.Constant */
+.highlight pre .kd, pre.code .kd { color: #859900 } /* Keyword.Declaration */
+.highlight pre .kn, pre.code .kn { color: #cb4b16 } /* Keyword.Namespace */
+.highlight pre .kp, pre.code .kp { color: #cb4b16 } /* Keyword.Pseudo */
+.highlight pre .kr, pre.code .kr { color: #859900 } /* Keyword.Reserved */
+.highlight pre .kt, pre.code .kt { color: #859900 } /* Keyword.Type */
+.highlight pre .ld, pre.code .ld { color: #839496 } /* Literal.Date */
+.highlight pre .m, pre.code .m { color: #2aa198 } /* Literal.Number */
+.highlight pre .s, pre.code .s { color: #2aa198 } /* Literal.String */
+.highlight pre .na, pre.code .na { color: #839496 } /* Name.Attribute */
+.highlight pre .nb, pre.code .nb { color: #268bd2 } /* Name.Builtin */
+.highlight pre .nc, pre.code .nc { color: #268bd2 } /* Name.Class */
+.highlight pre .no, pre.code .no { color: #b58900 } /* Name.Constant */
+.highlight pre .nd, pre.code .nd { color: #cb4b16 } /* Name.Decorator */
+.highlight pre .ni, pre.code .ni { color: #cb4b16 } /* Name.Entity */
+.highlight pre .ne, pre.code .ne { color: #cb4b16 } /* Name.Exception */
+.highlight pre .nf, pre.code .nf { color: #268bd2 } /* Name.Function */
+.highlight pre .nl, pre.code .nl { color: #839496 } /* Name.Label */
+.highlight pre .nn, pre.code .nn { color: #b58900 } /* Name.Namespace */
+.highlight pre .nx, pre.code .nx { color: #839496 } /* Name.Other */
+.highlight pre .py, pre.code .py { color: #268bd2 } /* Name.Property */
+.highlight pre .nt, pre.code .nt { color: #859900 } /* Name.Tag */
+.highlight pre .nv, pre.code .nv { color: #cb4b16 } /* Name.Variable */
+.highlight pre .ow, pre.code .ow { color: #859900 } /* Operator.Word */
+.highlight pre .w, pre.code .w { color: #002b36 } /* Text.Whitespace */
+.highlight pre .mf, pre.code .mf { color: #2aa198 } /* Literal.Number.Float */
+.highlight pre .mh, pre.code .mh { color: #2aa198 } /* Literal.Number.Hex */
+.highlight pre .mi, pre.code .mi { color: #2aa198 } /* Literal.Number.Integer */
+.highlight pre .mo, pre.code .mo { color: #2aa198 } /* Literal.Number.Oct */
+.highlight pre .sb, pre.code .sb { color: #2aa198 } /* Literal.String.Backtick */
+.highlight pre .sc, pre.code .sc { color: #2aa198 } /* Literal.String.Char */
+.highlight pre .sd, pre.code .sd { color: #2aa198 } /* Literal.String.Doc */
+.highlight pre .s, pre.code .s2 { color: #2aa198 } /* Literal.String.Double */
+.highlight pre .se, pre.code .se { color: #cb4b16 } /* Literal.String.Escape */
+.highlight pre .sh, pre.code .sh { color: #2aa198 } /* Literal.String.Heredoc */
+.highlight pre .si, pre.code .si { color: #cb4b16 } /* Literal.String.Interpol */
+.highlight pre .sx, pre.code .sx { color: #2aa198 } /* Literal.String.Other */
+.highlight pre .sr, pre.code .sr { color: #2aa198 } /* Literal.String.Regex */
+.highlight pre .s, pre.code .s1 { color: #2aa198 } /* Literal.String.Single */
+.highlight pre .ss, pre.code .ss { color: #2aa198 } /* Literal.String.Symbol */
+.highlight pre .bp, pre.code .bp { color: #268bd2; font-weight: bold } /* Name.Builtin.Pseudo */
+.highlight pre .vc, pre.code .vc { color: #268bd2 } /* Name.Variable.Class */
+.highlight pre .vg, pre.code .vg { color: #268bd2 } /* Name.Variable.Global */
+.highlight pre .vi, pre.code .vi { color: #268bd2 } /* Name.Variable.Instance */
+.highlight pre .il, pre.code .il { color: #2aa198 } /* Literal.Number.Integer.Long */

--- a/pelican-bootstrap3/static/css/pygments/solarizedlight.css
+++ b/pelican-bootstrap3/static/css/pygments/solarizedlight.css
@@ -1,70 +1,70 @@
-.highlight pre .hll { background-color: #ffffcc }
-.highlight pre, .highlighttable pre { background: #fdf6e3; color: #657b83 }
-.highlight pre .c { color: #93a1a1; font-style: italic } /* Comment */
-.highlight pre .err { color: #dc322f } /* Error */
-.highlight pre .g { color: #657b83 } /* Generic */
-.highlight pre .k { color: #859900 } /* Keyword */
-.highlight pre .l { color: #657b83 } /* Literal */
-.highlight pre .n { color: #586e75 } /* Name */
-.highlight pre .o { color: #657b83 } /* Operator */
-.highlight pre .x { color: #657b83 } /* Other */
-.highlight pre .p { color: #657b83 } /* Punctuation */
-.highlight pre .cm { color: #93a1a1; font-style: italic } /* Comment.Multiline */
-.highlight pre .cp { color: #93a1a1; font-style: italic } /* Comment.Preproc */
-.highlight pre .c1 { color: #93a1a1; font-style: italic } /* Comment.Single */
-.highlight pre .cs { color: #93a1a1; font-style: italic } /* Comment.Special */
-.highlight pre .gd { color: #657b83 } /* Generic.Deleted */
-.highlight pre .ge { color: #657b83 } /* Generic.Emph */
-.highlight pre .gr { color: #657b83 } /* Generic.Error */
-.highlight pre .gh { color: #657b83 } /* Generic.Heading */
-.highlight pre .gi { color: #657b83 } /* Generic.Inserted */
-.highlight pre .go { color: #657b83 } /* Generic.Output */
-.highlight pre .gp { color: #657b83 } /* Generic.Prompt */
-.highlight pre .gs { color: #657b83 } /* Generic.Strong */
-.highlight pre .gu { color: #657b83 } /* Generic.Subheading */
-.highlight pre .gt { color: #657b83 } /* Generic.Traceback */
-.highlight pre .kc { color: #859900 } /* Keyword.Constant */
-.highlight pre .kd { color: #859900 } /* Keyword.Declaration */
-.highlight pre .kn { color: #cb4b16 } /* Keyword.Namespace */
-.highlight pre .kp { color: #cb4b16 } /* Keyword.Pseudo */
-.highlight pre .kr { color: #859900 } /* Keyword.Reserved */
-.highlight pre .kt { color: #859900 } /* Keyword.Type */
-.highlight pre .ld { color: #657b83 } /* Literal.Date */
-.highlight pre .m { color: #2aa198 } /* Literal.Number */
-.highlight pre .s { color: #2aa198 } /* Literal.String */
-.highlight pre .na { color: #657b83 } /* Name.Attribute */
-.highlight pre .nb { color: #268bd2 } /* Name.Builtin */
-.highlight pre .nc { color: #268bd2 } /* Name.Class */
-.highlight pre .no { color: #b58900 } /* Name.Constant */
-.highlight pre .nd { color: #cb4b16 } /* Name.Decorator */
-.highlight pre .ni { color: #cb4b16 } /* Name.Entity */
-.highlight pre .ne { color: #cb4b16 } /* Name.Exception */
-.highlight pre .nf { color: #268bd2 } /* Name.Function */
-.highlight pre .nl { color: #657b83 } /* Name.Label */
-.highlight pre .nn { color: #b58900 } /* Name.Namespace */
-.highlight pre .nx { color: #657b83 } /* Name.Other */
-.highlight pre .py { color: #268bd2 } /* Name.Property */
-.highlight pre .nt { color: #859900 } /* Name.Tag */
-.highlight pre .nv { color: #cb4b16 } /* Name.Variable */
-.highlight pre .ow { color: #859900 } /* Operator.Word */
-.highlight pre .w { color: #fdf6e3 } /* Text.Whitespace */
-.highlight pre .mf { color: #2aa198 } /* Literal.Number.Float */
-.highlight pre .mh { color: #2aa198 } /* Literal.Number.Hex */
-.highlight pre .mi { color: #2aa198 } /* Literal.Number.Integer */
-.highlight pre .mo { color: #2aa198 } /* Literal.Number.Oct */
-.highlight pre .sb { color: #2aa198 } /* Literal.String.Backtick */
-.highlight pre .sc { color: #2aa198 } /* Literal.String.Char */
-.highlight pre .sd { color: #2aa198 } /* Literal.String.Doc */
-.highlight pre .s2 { color: #2aa198 } /* Literal.String.Double */
-.highlight pre .se { color: #cb4b16 } /* Literal.String.Escape */
-.highlight pre .sh { color: #2aa198 } /* Literal.String.Heredoc */
-.highlight pre .si { color: #cb4b16 } /* Literal.String.Interpol */
-.highlight pre .sx { color: #2aa198 } /* Literal.String.Other */
-.highlight pre .sr { color: #2aa198 } /* Literal.String.Regex */
-.highlight pre .s1 { color: #2aa198 } /* Literal.String.Single */
-.highlight pre .ss { color: #2aa198 } /* Literal.String.Symbol */
-.highlight pre .bp { color: #268bd2; font-weight: bold } /* Name.Builtin.Pseudo */
-.highlight pre .vc { color: #268bd2 } /* Name.Variable.Class */
-.highlight pre .vg { color: #268bd2 } /* Name.Variable.Global */
-.highlight pre .vi { color: #268bd2 } /* Name.Variable.Instance */
-.highlight pre .il { color: #2aa198 } /* Literal.Number.Integer.Long */
+.highlight pre .hll, pre.code .hll { background-color: #ffffcc }
+.highlight pre, pre.code, .highlighttable pre { background: #fdf6e3; color: #657b83 }
+.highlight pre .c, pre.code .c { color: #93a1a1; font-style: italic } /* Comment */
+.highlight pre .err, pre.code .err { color: #dc322f } /* Error */
+.highlight pre .g, pre.code .g { color: #657b83 } /* Generic */
+.highlight pre .k, pre.code .k { color: #859900 } /* Keyword */
+.highlight pre .l, pre.code .l { color: #657b83 } /* Literal */
+.highlight pre .n, pre.code .n { color: #586e75 } /* Name */
+.highlight pre .o, pre.code .o { color: #657b83 } /* Operator */
+.highlight pre .x, pre.code .x { color: #657b83 } /* Other */
+.highlight pre .p, pre.code .p { color: #657b83 } /* Punctuation */
+.highlight pre .cm, pre.code .cm { color: #93a1a1; font-style: italic } /* Comment.Multiline */
+.highlight pre .cp, pre.code .cp { color: #93a1a1; font-style: italic } /* Comment.Preproc */
+.highlight pre .c, pre.code .c1 { color: #93a1a1; font-style: italic } /* Comment.Single */
+.highlight pre .cs, pre.code .cs { color: #93a1a1; font-style: italic } /* Comment.Special */
+.highlight pre .gd, pre.code .gd { color: #657b83 } /* Generic.Deleted */
+.highlight pre .ge, pre.code .ge { color: #657b83 } /* Generic.Emph */
+.highlight pre .gr, pre.code .gr { color: #657b83 } /* Generic.Error */
+.highlight pre .gh, pre.code .gh { color: #657b83 } /* Generic.Heading */
+.highlight pre .gi, pre.code .gi { color: #657b83 } /* Generic.Inserted */
+.highlight pre .go, pre.code .go { color: #657b83 } /* Generic.Output */
+.highlight pre .gp, pre.code .gp { color: #657b83 } /* Generic.Prompt */
+.highlight pre .gs, pre.code .gs { color: #657b83 } /* Generic.Strong */
+.highlight pre .gu, pre.code .gu { color: #657b83 } /* Generic.Subheading */
+.highlight pre .gt, pre.code .gt { color: #657b83 } /* Generic.Traceback */
+.highlight pre .kc, pre.code .kc { color: #859900 } /* Keyword.Constant */
+.highlight pre .kd, pre.code .kd { color: #859900 } /* Keyword.Declaration */
+.highlight pre .kn, pre.code .kn { color: #cb4b16 } /* Keyword.Namespace */
+.highlight pre .kp, pre.code .kp { color: #cb4b16 } /* Keyword.Pseudo */
+.highlight pre .kr, pre.code .kr { color: #859900 } /* Keyword.Reserved */
+.highlight pre .kt, pre.code .kt { color: #859900 } /* Keyword.Type */
+.highlight pre .ld, pre.code .ld { color: #657b83 } /* Literal.Date */
+.highlight pre .m, pre.code .m { color: #2aa198 } /* Literal.Number */
+.highlight pre .s, pre.code .s { color: #2aa198 } /* Literal.String */
+.highlight pre .na, pre.code .na { color: #657b83 } /* Name.Attribute */
+.highlight pre .nb, pre.code .nb { color: #268bd2 } /* Name.Builtin */
+.highlight pre .nc, pre.code .nc { color: #268bd2 } /* Name.Class */
+.highlight pre .no, pre.code .no { color: #b58900 } /* Name.Constant */
+.highlight pre .nd, pre.code .nd { color: #cb4b16 } /* Name.Decorator */
+.highlight pre .ni, pre.code .ni { color: #cb4b16 } /* Name.Entity */
+.highlight pre .ne, pre.code .ne { color: #cb4b16 } /* Name.Exception */
+.highlight pre .nf, pre.code .nf { color: #268bd2 } /* Name.Function */
+.highlight pre .nl, pre.code .nl { color: #657b83 } /* Name.Label */
+.highlight pre .nn, pre.code .nn { color: #b58900 } /* Name.Namespace */
+.highlight pre .nx, pre.code .nx { color: #657b83 } /* Name.Other */
+.highlight pre .py, pre.code .py { color: #268bd2 } /* Name.Property */
+.highlight pre .nt, pre.code .nt { color: #859900 } /* Name.Tag */
+.highlight pre .nv, pre.code .nv { color: #cb4b16 } /* Name.Variable */
+.highlight pre .ow, pre.code .ow { color: #859900 } /* Operator.Word */
+.highlight pre .w, pre.code .w { color: #fdf6e3 } /* Text.Whitespace */
+.highlight pre .mf, pre.code .mf { color: #2aa198 } /* Literal.Number.Float */
+.highlight pre .mh, pre.code .mh { color: #2aa198 } /* Literal.Number.Hex */
+.highlight pre .mi, pre.code .mi { color: #2aa198 } /* Literal.Number.Integer */
+.highlight pre .mo, pre.code .mo { color: #2aa198 } /* Literal.Number.Oct */
+.highlight pre .sb, pre.code .sb { color: #2aa198 } /* Literal.String.Backtick */
+.highlight pre .sc, pre.code .sc { color: #2aa198 } /* Literal.String.Char */
+.highlight pre .sd, pre.code .sd { color: #2aa198 } /* Literal.String.Doc */
+.highlight pre .s, pre.code .s2 { color: #2aa198 } /* Literal.String.Double */
+.highlight pre .se, pre.code .se { color: #cb4b16 } /* Literal.String.Escape */
+.highlight pre .sh, pre.code .sh { color: #2aa198 } /* Literal.String.Heredoc */
+.highlight pre .si, pre.code .si { color: #cb4b16 } /* Literal.String.Interpol */
+.highlight pre .sx, pre.code .sx { color: #2aa198 } /* Literal.String.Other */
+.highlight pre .sr, pre.code .sr { color: #2aa198 } /* Literal.String.Regex */
+.highlight pre .s, pre.code .s1 { color: #2aa198 } /* Literal.String.Single */
+.highlight pre .ss, pre.code .ss { color: #2aa198 } /* Literal.String.Symbol */
+.highlight pre .bp, pre.code .bp { color: #268bd2; font-weight: bold } /* Name.Builtin.Pseudo */
+.highlight pre .vc, pre.code .vc { color: #268bd2 } /* Name.Variable.Class */
+.highlight pre .vg, pre.code .vg { color: #268bd2 } /* Name.Variable.Global */
+.highlight pre .vi, pre.code .vi { color: #268bd2 } /* Name.Variable.Instance */
+.highlight pre .il, pre.code .il { color: #2aa198 } /* Literal.Number.Integer.Long */

--- a/pelican-bootstrap3/static/css/pygments/tango.css
+++ b/pelican-bootstrap3/static/css/pygments/tango.css
@@ -1,71 +1,71 @@
-.highlight pre .hll { background-color: #ffffcc }
-.highlight pre  { background: #f8f8f8; }
-.highlight pre .c { color: #8f5902; font-style: italic } /* Comment */
-.highlight pre .err { color: #a40000; border: 1px solid #ef2929 } /* Error */
-.highlight pre .g { color: #000000 } /* Generic */
-.highlight pre .k { color: #204a87; font-weight: bold } /* Keyword */
-.highlight pre .l { color: #000000 } /* Literal */
-.highlight pre .n { color: #000000 } /* Name */
-.highlight pre .o { color: #ce5c00; font-weight: bold } /* Operator */
-.highlight pre .x { color: #000000 } /* Other */
-.highlight pre .p { color: #000000; font-weight: bold } /* Punctuation */
-.highlight pre .cm { color: #8f5902; font-style: italic } /* Comment.Multiline */
-.highlight pre .cp { color: #8f5902; font-style: italic } /* Comment.Preproc */
-.highlight pre .c1 { color: #8f5902; font-style: italic } /* Comment.Single */
-.highlight pre .cs { color: #8f5902; font-style: italic } /* Comment.Special */
-.highlight pre .gd { color: #a40000 } /* Generic.Deleted */
-.highlight pre .ge { color: #000000; font-style: italic } /* Generic.Emph */
-.highlight pre .gr { color: #ef2929 } /* Generic.Error */
-.highlight pre .gh { color: #000080; font-weight: bold } /* Generic.Heading */
-.highlight pre .gi { color: #00A000 } /* Generic.Inserted */
-.highlight pre .go { color: #000000; font-style: italic } /* Generic.Output */
-.highlight pre .gp { color: #8f5902 } /* Generic.Prompt */
-.highlight pre .gs { color: #000000; font-weight: bold } /* Generic.Strong */
-.highlight pre .gu { color: #800080; font-weight: bold } /* Generic.Subheading */
-.highlight pre .gt { color: #a40000; font-weight: bold } /* Generic.Traceback */
-.highlight pre .kc { color: #204a87; font-weight: bold } /* Keyword.Constant */
-.highlight pre .kd { color: #204a87; font-weight: bold } /* Keyword.Declaration */
-.highlight pre .kn { color: #204a87; font-weight: bold } /* Keyword.Namespace */
-.highlight pre .kp { color: #204a87; font-weight: bold } /* Keyword.Pseudo */
-.highlight pre .kr { color: #204a87; font-weight: bold } /* Keyword.Reserved */
-.highlight pre .kt { color: #204a87; font-weight: bold } /* Keyword.Type */
-.highlight pre .ld { color: #000000 } /* Literal.Date */
-.highlight pre .m { color: #0000cf; font-weight: bold } /* Literal.Number */
-.highlight pre .s { color: #4e9a06 } /* Literal.String */
-.highlight pre .na { color: #c4a000 } /* Name.Attribute */
-.highlight pre .nb { color: #204a87 } /* Name.Builtin */
-.highlight pre .nc { color: #000000 } /* Name.Class */
-.highlight pre .no { color: #000000 } /* Name.Constant */
-.highlight pre .nd { color: #5c35cc; font-weight: bold } /* Name.Decorator */
-.highlight pre .ni { color: #ce5c00 } /* Name.Entity */
-.highlight pre .ne { color: #cc0000; font-weight: bold } /* Name.Exception */
-.highlight pre .nf { color: #000000 } /* Name.Function */
-.highlight pre .nl { color: #f57900 } /* Name.Label */
-.highlight pre .nn { color: #000000 } /* Name.Namespace */
-.highlight pre .nx { color: #000000 } /* Name.Other */
-.highlight pre .py { color: #000000 } /* Name.Property */
-.highlight pre .nt { color: #204a87; font-weight: bold } /* Name.Tag */
-.highlight pre .nv { color: #000000 } /* Name.Variable */
-.highlight pre .ow { color: #204a87; font-weight: bold } /* Operator.Word */
-.highlight pre .w { color: #f8f8f8; text-decoration: underline } /* Text.Whitespace */
-.highlight pre .mb { color: #0000cf; font-weight: bold } /* Literal.Number.Bin */
-.highlight pre .mf { color: #0000cf; font-weight: bold } /* Literal.Number.Float */
-.highlight pre .mh { color: #0000cf; font-weight: bold } /* Literal.Number.Hex */
-.highlight pre .mi { color: #0000cf; font-weight: bold } /* Literal.Number.Integer */
-.highlight pre .mo { color: #0000cf; font-weight: bold } /* Literal.Number.Oct */
-.highlight pre .sb { color: #4e9a06 } /* Literal.String.Backtick */
-.highlight pre .sc { color: #4e9a06 } /* Literal.String.Char */
-.highlight pre .sd { color: #8f5902; font-style: italic } /* Literal.String.Doc */
-.highlight pre .s2 { color: #4e9a06 } /* Literal.String.Double */
-.highlight pre .se { color: #4e9a06 } /* Literal.String.Escape */
-.highlight pre .sh { color: #4e9a06 } /* Literal.String.Heredoc */
-.highlight pre .si { color: #4e9a06 } /* Literal.String.Interpol */
-.highlight pre .sx { color: #4e9a06 } /* Literal.String.Other */
-.highlight pre .sr { color: #4e9a06 } /* Literal.String.Regex */
-.highlight pre .s1 { color: #4e9a06 } /* Literal.String.Single */
-.highlight pre .ss { color: #4e9a06 } /* Literal.String.Symbol */
-.highlight pre .bp { color: #3465a4 } /* Name.Builtin.Pseudo */
-.highlight pre .vc { color: #000000 } /* Name.Variable.Class */
-.highlight pre .vg { color: #000000 } /* Name.Variable.Global */
-.highlight pre .vi { color: #000000 } /* Name.Variable.Instance */
-.highlight pre .il { color: #0000cf; font-weight: bold } /* Literal.Number.Integer.Long */
+.highlight pre .hll, pre.code .hll { background-color: #ffffcc }
+.highlight pre, pre.code { background: #f8f8f8; }
+.highlight pre .c, pre.code .c { color: #8f5902; font-style: italic } /* Comment */
+.highlight pre .err, pre.code .err { color: #a40000; border: 1px solid #ef2929 } /* Error */
+.highlight pre .g, pre.code .g { color: #000000 } /* Generic */
+.highlight pre .k, pre.code .k { color: #204a87; font-weight: bold } /* Keyword */
+.highlight pre .l, pre.code .l { color: #000000 } /* Literal */
+.highlight pre .n, pre.code .n { color: #000000 } /* Name */
+.highlight pre .o, pre.code .o { color: #ce5c00; font-weight: bold } /* Operator */
+.highlight pre .x, pre.code .x { color: #000000 } /* Other */
+.highlight pre .p, pre.code .p { color: #000000; font-weight: bold } /* Punctuation */
+.highlight pre .cm, pre.code .cm { color: #8f5902; font-style: italic } /* Comment.Multiline */
+.highlight pre .cp, pre.code .cp { color: #8f5902; font-style: italic } /* Comment.Preproc */
+.highlight pre .c, pre.code .c1 { color: #8f5902; font-style: italic } /* Comment.Single */
+.highlight pre .cs, pre.code .cs { color: #8f5902; font-style: italic } /* Comment.Special */
+.highlight pre .gd, pre.code .gd { color: #a40000 } /* Generic.Deleted */
+.highlight pre .ge, pre.code .ge { color: #000000; font-style: italic } /* Generic.Emph */
+.highlight pre .gr, pre.code .gr { color: #ef2929 } /* Generic.Error */
+.highlight pre .gh, pre.code .gh { color: #000080; font-weight: bold } /* Generic.Heading */
+.highlight pre .gi, pre.code .gi { color: #00A000 } /* Generic.Inserted */
+.highlight pre .go, pre.code .go { color: #000000; font-style: italic } /* Generic.Output */
+.highlight pre .gp, pre.code .gp { color: #8f5902 } /* Generic.Prompt */
+.highlight pre .gs, pre.code .gs { color: #000000; font-weight: bold } /* Generic.Strong */
+.highlight pre .gu, pre.code .gu { color: #800080; font-weight: bold } /* Generic.Subheading */
+.highlight pre .gt, pre.code .gt { color: #a40000; font-weight: bold } /* Generic.Traceback */
+.highlight pre .kc, pre.code .kc { color: #204a87; font-weight: bold } /* Keyword.Constant */
+.highlight pre .kd, pre.code .kd { color: #204a87; font-weight: bold } /* Keyword.Declaration */
+.highlight pre .kn, pre.code .kn { color: #204a87; font-weight: bold } /* Keyword.Namespace */
+.highlight pre .kp, pre.code .kp { color: #204a87; font-weight: bold } /* Keyword.Pseudo */
+.highlight pre .kr, pre.code .kr { color: #204a87; font-weight: bold } /* Keyword.Reserved */
+.highlight pre .kt, pre.code .kt { color: #204a87; font-weight: bold } /* Keyword.Type */
+.highlight pre .ld, pre.code .ld { color: #000000 } /* Literal.Date */
+.highlight pre .m, pre.code .m { color: #0000cf; font-weight: bold } /* Literal.Number */
+.highlight pre .s, pre.code .s { color: #4e9a06 } /* Literal.String */
+.highlight pre .na, pre.code .na { color: #c4a000 } /* Name.Attribute */
+.highlight pre .nb, pre.code .nb { color: #204a87 } /* Name.Builtin */
+.highlight pre .nc, pre.code .nc { color: #000000 } /* Name.Class */
+.highlight pre .no, pre.code .no { color: #000000 } /* Name.Constant */
+.highlight pre .nd, pre.code .nd { color: #5c35cc; font-weight: bold } /* Name.Decorator */
+.highlight pre .ni, pre.code .ni { color: #ce5c00 } /* Name.Entity */
+.highlight pre .ne, pre.code .ne { color: #cc0000; font-weight: bold } /* Name.Exception */
+.highlight pre .nf, pre.code .nf { color: #000000 } /* Name.Function */
+.highlight pre .nl, pre.code .nl { color: #f57900 } /* Name.Label */
+.highlight pre .nn, pre.code .nn { color: #000000 } /* Name.Namespace */
+.highlight pre .nx, pre.code .nx { color: #000000 } /* Name.Other */
+.highlight pre .py, pre.code .py { color: #000000 } /* Name.Property */
+.highlight pre .nt, pre.code .nt { color: #204a87; font-weight: bold } /* Name.Tag */
+.highlight pre .nv, pre.code .nv { color: #000000 } /* Name.Variable */
+.highlight pre .ow, pre.code .ow { color: #204a87; font-weight: bold } /* Operator.Word */
+.highlight pre .w, pre.code .w { color: #f8f8f8; text-decoration: underline } /* Text.Whitespace */
+.highlight pre .mb, pre.code .mb { color: #0000cf; font-weight: bold } /* Literal.Number.Bin */
+.highlight pre .mf, pre.code .mf { color: #0000cf; font-weight: bold } /* Literal.Number.Float */
+.highlight pre .mh, pre.code .mh { color: #0000cf; font-weight: bold } /* Literal.Number.Hex */
+.highlight pre .mi, pre.code .mi { color: #0000cf; font-weight: bold } /* Literal.Number.Integer */
+.highlight pre .mo, pre.code .mo { color: #0000cf; font-weight: bold } /* Literal.Number.Oct */
+.highlight pre .sb, pre.code .sb { color: #4e9a06 } /* Literal.String.Backtick */
+.highlight pre .sc, pre.code .sc { color: #4e9a06 } /* Literal.String.Char */
+.highlight pre .sd, pre.code .sd { color: #8f5902; font-style: italic } /* Literal.String.Doc */
+.highlight pre .s, pre.code .s2 { color: #4e9a06 } /* Literal.String.Double */
+.highlight pre .se, pre.code .se { color: #4e9a06 } /* Literal.String.Escape */
+.highlight pre .sh, pre.code .sh { color: #4e9a06 } /* Literal.String.Heredoc */
+.highlight pre .si, pre.code .si { color: #4e9a06 } /* Literal.String.Interpol */
+.highlight pre .sx, pre.code .sx { color: #4e9a06 } /* Literal.String.Other */
+.highlight pre .sr, pre.code .sr { color: #4e9a06 } /* Literal.String.Regex */
+.highlight pre .s, pre.code .s1 { color: #4e9a06 } /* Literal.String.Single */
+.highlight pre .ss, pre.code .ss { color: #4e9a06 } /* Literal.String.Symbol */
+.highlight pre .bp, pre.code .bp { color: #3465a4 } /* Name.Builtin.Pseudo */
+.highlight pre .vc, pre.code .vc { color: #000000 } /* Name.Variable.Class */
+.highlight pre .vg, pre.code .vg { color: #000000 } /* Name.Variable.Global */
+.highlight pre .vi, pre.code .vi { color: #000000 } /* Name.Variable.Instance */
+.highlight pre .il, pre.code .il { color: #0000cf; font-weight: bold } /* Literal.Number.Integer.Long */

--- a/pelican-bootstrap3/static/css/pygments/trac.css
+++ b/pelican-bootstrap3/static/css/pygments/trac.css
@@ -1,61 +1,61 @@
-.highlight pre .hll { background-color: #ffffcc }
-.highlight pre  { background: #ffffff; }
-.highlight pre .c { color: #999988; font-style: italic } /* Comment */
-.highlight pre .err { color: #a61717; background-color: #e3d2d2 } /* Error */
-.highlight pre .k { font-weight: bold } /* Keyword */
-.highlight pre .o { font-weight: bold } /* Operator */
-.highlight pre .cm { color: #999988; font-style: italic } /* Comment.Multiline */
-.highlight pre .cp { color: #999999; font-weight: bold } /* Comment.Preproc */
-.highlight pre .c1 { color: #999988; font-style: italic } /* Comment.Single */
-.highlight pre .cs { color: #999999; font-weight: bold; font-style: italic } /* Comment.Special */
-.highlight pre .gd { color: #000000; background-color: #ffdddd } /* Generic.Deleted */
-.highlight pre .ge { font-style: italic } /* Generic.Emph */
-.highlight pre .gr { color: #aa0000 } /* Generic.Error */
-.highlight pre .gh { color: #999999 } /* Generic.Heading */
-.highlight pre .gi { color: #000000; background-color: #ddffdd } /* Generic.Inserted */
-.highlight pre .go { color: #888888 } /* Generic.Output */
-.highlight pre .gp { color: #555555 } /* Generic.Prompt */
-.highlight pre .gs { font-weight: bold } /* Generic.Strong */
-.highlight pre .gu { color: #aaaaaa } /* Generic.Subheading */
-.highlight pre .gt { color: #aa0000 } /* Generic.Traceback */
-.highlight pre .kc { font-weight: bold } /* Keyword.Constant */
-.highlight pre .kd { font-weight: bold } /* Keyword.Declaration */
-.highlight pre .kn { font-weight: bold } /* Keyword.Namespace */
-.highlight pre .kp { font-weight: bold } /* Keyword.Pseudo */
-.highlight pre .kr { font-weight: bold } /* Keyword.Reserved */
-.highlight pre .kt { color: #445588; font-weight: bold } /* Keyword.Type */
-.highlight pre .m { color: #009999 } /* Literal.Number */
-.highlight pre .s { color: #bb8844 } /* Literal.String */
-.highlight pre .na { color: #008080 } /* Name.Attribute */
-.highlight pre .nb { color: #999999 } /* Name.Builtin */
-.highlight pre .nc { color: #445588; font-weight: bold } /* Name.Class */
-.highlight pre .no { color: #008080 } /* Name.Constant */
-.highlight pre .ni { color: #800080 } /* Name.Entity */
-.highlight pre .ne { color: #990000; font-weight: bold } /* Name.Exception */
-.highlight pre .nf { color: #990000; font-weight: bold } /* Name.Function */
-.highlight pre .nn { color: #555555 } /* Name.Namespace */
-.highlight pre .nt { color: #000080 } /* Name.Tag */
-.highlight pre .nv { color: #008080 } /* Name.Variable */
-.highlight pre .ow { font-weight: bold } /* Operator.Word */
-.highlight pre .w { color: #bbbbbb } /* Text.Whitespace */
-.highlight pre .mb { color: #009999 } /* Literal.Number.Bin */
-.highlight pre .mf { color: #009999 } /* Literal.Number.Float */
-.highlight pre .mh { color: #009999 } /* Literal.Number.Hex */
-.highlight pre .mi { color: #009999 } /* Literal.Number.Integer */
-.highlight pre .mo { color: #009999 } /* Literal.Number.Oct */
-.highlight pre .sb { color: #bb8844 } /* Literal.String.Backtick */
-.highlight pre .sc { color: #bb8844 } /* Literal.String.Char */
-.highlight pre .sd { color: #bb8844 } /* Literal.String.Doc */
-.highlight pre .s2 { color: #bb8844 } /* Literal.String.Double */
-.highlight pre .se { color: #bb8844 } /* Literal.String.Escape */
-.highlight pre .sh { color: #bb8844 } /* Literal.String.Heredoc */
-.highlight pre .si { color: #bb8844 } /* Literal.String.Interpol */
-.highlight pre .sx { color: #bb8844 } /* Literal.String.Other */
-.highlight pre .sr { color: #808000 } /* Literal.String.Regex */
-.highlight pre .s1 { color: #bb8844 } /* Literal.String.Single */
-.highlight pre .ss { color: #bb8844 } /* Literal.String.Symbol */
-.highlight pre .bp { color: #999999 } /* Name.Builtin.Pseudo */
-.highlight pre .vc { color: #008080 } /* Name.Variable.Class */
-.highlight pre .vg { color: #008080 } /* Name.Variable.Global */
-.highlight pre .vi { color: #008080 } /* Name.Variable.Instance */
-.highlight pre .il { color: #009999 } /* Literal.Number.Integer.Long */
+.highlight pre .hll, pre.code .hll { background-color: #ffffcc }
+.highlight pre, pre.code { background: #ffffff; }
+.highlight pre .c, pre.code .c { color: #999988; font-style: italic } /* Comment */
+.highlight pre .err, pre.code .err { color: #a61717; background-color: #e3d2d2 } /* Error */
+.highlight pre .k, pre.code .k { font-weight: bold } /* Keyword */
+.highlight pre .o, pre.code .o { font-weight: bold } /* Operator */
+.highlight pre .cm, pre.code .cm { color: #999988; font-style: italic } /* Comment.Multiline */
+.highlight pre .cp, pre.code .cp { color: #999999; font-weight: bold } /* Comment.Preproc */
+.highlight pre .c, pre.code .c1 { color: #999988; font-style: italic } /* Comment.Single */
+.highlight pre .cs, pre.code .cs { color: #999999; font-weight: bold; font-style: italic } /* Comment.Special */
+.highlight pre .gd, pre.code .gd { color: #000000; background-color: #ffdddd } /* Generic.Deleted */
+.highlight pre .ge, pre.code .ge { font-style: italic } /* Generic.Emph */
+.highlight pre .gr, pre.code .gr { color: #aa0000 } /* Generic.Error */
+.highlight pre .gh, pre.code .gh { color: #999999 } /* Generic.Heading */
+.highlight pre .gi, pre.code .gi { color: #000000; background-color: #ddffdd } /* Generic.Inserted */
+.highlight pre .go, pre.code .go { color: #888888 } /* Generic.Output */
+.highlight pre .gp, pre.code .gp { color: #555555 } /* Generic.Prompt */
+.highlight pre .gs, pre.code .gs { font-weight: bold } /* Generic.Strong */
+.highlight pre .gu, pre.code .gu { color: #aaaaaa } /* Generic.Subheading */
+.highlight pre .gt, pre.code .gt { color: #aa0000 } /* Generic.Traceback */
+.highlight pre .kc, pre.code .kc { font-weight: bold } /* Keyword.Constant */
+.highlight pre .kd, pre.code .kd { font-weight: bold } /* Keyword.Declaration */
+.highlight pre .kn, pre.code .kn { font-weight: bold } /* Keyword.Namespace */
+.highlight pre .kp, pre.code .kp { font-weight: bold } /* Keyword.Pseudo */
+.highlight pre .kr, pre.code .kr { font-weight: bold } /* Keyword.Reserved */
+.highlight pre .kt, pre.code .kt { color: #445588; font-weight: bold } /* Keyword.Type */
+.highlight pre .m, pre.code .m { color: #009999 } /* Literal.Number */
+.highlight pre .s, pre.code .s { color: #bb8844 } /* Literal.String */
+.highlight pre .na, pre.code .na { color: #008080 } /* Name.Attribute */
+.highlight pre .nb, pre.code .nb { color: #999999 } /* Name.Builtin */
+.highlight pre .nc, pre.code .nc { color: #445588; font-weight: bold } /* Name.Class */
+.highlight pre .no, pre.code .no { color: #008080 } /* Name.Constant */
+.highlight pre .ni, pre.code .ni { color: #800080 } /* Name.Entity */
+.highlight pre .ne, pre.code .ne { color: #990000; font-weight: bold } /* Name.Exception */
+.highlight pre .nf, pre.code .nf { color: #990000; font-weight: bold } /* Name.Function */
+.highlight pre .nn, pre.code .nn { color: #555555 } /* Name.Namespace */
+.highlight pre .nt, pre.code .nt { color: #000080 } /* Name.Tag */
+.highlight pre .nv, pre.code .nv { color: #008080 } /* Name.Variable */
+.highlight pre .ow, pre.code .ow { font-weight: bold } /* Operator.Word */
+.highlight pre .w, pre.code .w { color: #bbbbbb } /* Text.Whitespace */
+.highlight pre .mb, pre.code .mb { color: #009999 } /* Literal.Number.Bin */
+.highlight pre .mf, pre.code .mf { color: #009999 } /* Literal.Number.Float */
+.highlight pre .mh, pre.code .mh { color: #009999 } /* Literal.Number.Hex */
+.highlight pre .mi, pre.code .mi { color: #009999 } /* Literal.Number.Integer */
+.highlight pre .mo, pre.code .mo { color: #009999 } /* Literal.Number.Oct */
+.highlight pre .sb, pre.code .sb { color: #bb8844 } /* Literal.String.Backtick */
+.highlight pre .sc, pre.code .sc { color: #bb8844 } /* Literal.String.Char */
+.highlight pre .sd, pre.code .sd { color: #bb8844 } /* Literal.String.Doc */
+.highlight pre .s, pre.code .s2 { color: #bb8844 } /* Literal.String.Double */
+.highlight pre .se, pre.code .se { color: #bb8844 } /* Literal.String.Escape */
+.highlight pre .sh, pre.code .sh { color: #bb8844 } /* Literal.String.Heredoc */
+.highlight pre .si, pre.code .si { color: #bb8844 } /* Literal.String.Interpol */
+.highlight pre .sx, pre.code .sx { color: #bb8844 } /* Literal.String.Other */
+.highlight pre .sr, pre.code .sr { color: #808000 } /* Literal.String.Regex */
+.highlight pre .s, pre.code .s1 { color: #bb8844 } /* Literal.String.Single */
+.highlight pre .ss, pre.code .ss { color: #bb8844 } /* Literal.String.Symbol */
+.highlight pre .bp, pre.code .bp { color: #999999 } /* Name.Builtin.Pseudo */
+.highlight pre .vc, pre.code .vc { color: #008080 } /* Name.Variable.Class */
+.highlight pre .vg, pre.code .vg { color: #008080 } /* Name.Variable.Global */
+.highlight pre .vi, pre.code .vi { color: #008080 } /* Name.Variable.Instance */
+.highlight pre .il, pre.code .il { color: #009999 } /* Literal.Number.Integer.Long */

--- a/pelican-bootstrap3/static/css/pygments/vim.css
+++ b/pelican-bootstrap3/static/css/pygments/vim.css
@@ -1,72 +1,72 @@
-.highlight pre .hll { background-color: #222222 }
-.highlight pre  { background: #000000; color: #cccccc }
-.highlight pre .c { color: #000080 } /* Comment */
-.highlight pre .err { color: #cccccc; border: 1px solid #FF0000 } /* Error */
-.highlight pre .esc { color: #cccccc } /* Escape */
-.highlight pre .g { color: #cccccc } /* Generic */
-.highlight pre .k { color: #cdcd00 } /* Keyword */
-.highlight pre .l { color: #cccccc } /* Literal */
-.highlight pre .n { color: #cccccc } /* Name */
-.highlight pre .o { color: #3399cc } /* Operator */
-.highlight pre .x { color: #cccccc } /* Other */
-.highlight pre .p { color: #cccccc } /* Punctuation */
-.highlight pre .cm { color: #000080 } /* Comment.Multiline */
-.highlight pre .cp { color: #000080 } /* Comment.Preproc */
-.highlight pre .c1 { color: #000080 } /* Comment.Single */
-.highlight pre .cs { color: #cd0000; font-weight: bold } /* Comment.Special */
-.highlight pre .gd { color: #cd0000 } /* Generic.Deleted */
-.highlight pre .ge { color: #cccccc; font-style: italic } /* Generic.Emph */
-.highlight pre .gr { color: #FF0000 } /* Generic.Error */
-.highlight pre .gh { color: #000080; font-weight: bold } /* Generic.Heading */
-.highlight pre .gi { color: #00cd00 } /* Generic.Inserted */
-.highlight pre .go { color: #888888 } /* Generic.Output */
-.highlight pre .gp { color: #000080; font-weight: bold } /* Generic.Prompt */
-.highlight pre .gs { color: #cccccc; font-weight: bold } /* Generic.Strong */
-.highlight pre .gu { color: #800080; font-weight: bold } /* Generic.Subheading */
-.highlight pre .gt { color: #0044DD } /* Generic.Traceback */
-.highlight pre .kc { color: #cdcd00 } /* Keyword.Constant */
-.highlight pre .kd { color: #00cd00 } /* Keyword.Declaration */
-.highlight pre .kn { color: #cd00cd } /* Keyword.Namespace */
-.highlight pre .kp { color: #cdcd00 } /* Keyword.Pseudo */
-.highlight pre .kr { color: #cdcd00 } /* Keyword.Reserved */
-.highlight pre .kt { color: #00cd00 } /* Keyword.Type */
-.highlight pre .ld { color: #cccccc } /* Literal.Date */
-.highlight pre .m { color: #cd00cd } /* Literal.Number */
-.highlight pre .s { color: #cd0000 } /* Literal.String */
-.highlight pre .na { color: #cccccc } /* Name.Attribute */
-.highlight pre .nb { color: #cd00cd } /* Name.Builtin */
-.highlight pre .nc { color: #00cdcd } /* Name.Class */
-.highlight pre .no { color: #cccccc } /* Name.Constant */
-.highlight pre .nd { color: #cccccc } /* Name.Decorator */
-.highlight pre .ni { color: #cccccc } /* Name.Entity */
-.highlight pre .ne { color: #666699; font-weight: bold } /* Name.Exception */
-.highlight pre .nf { color: #cccccc } /* Name.Function */
-.highlight pre .nl { color: #cccccc } /* Name.Label */
-.highlight pre .nn { color: #cccccc } /* Name.Namespace */
-.highlight pre .nx { color: #cccccc } /* Name.Other */
-.highlight pre .py { color: #cccccc } /* Name.Property */
-.highlight pre .nt { color: #cccccc } /* Name.Tag */
-.highlight pre .nv { color: #00cdcd } /* Name.Variable */
-.highlight pre .ow { color: #cdcd00 } /* Operator.Word */
-.highlight pre .w { color: #cccccc } /* Text.Whitespace */
-.highlight pre .mb { color: #cd00cd } /* Literal.Number.Bin */
-.highlight pre .mf { color: #cd00cd } /* Literal.Number.Float */
-.highlight pre .mh { color: #cd00cd } /* Literal.Number.Hex */
-.highlight pre .mi { color: #cd00cd } /* Literal.Number.Integer */
-.highlight pre .mo { color: #cd00cd } /* Literal.Number.Oct */
-.highlight pre .sb { color: #cd0000 } /* Literal.String.Backtick */
-.highlight pre .sc { color: #cd0000 } /* Literal.String.Char */
-.highlight pre .sd { color: #cd0000 } /* Literal.String.Doc */
-.highlight pre .s2 { color: #cd0000 } /* Literal.String.Double */
-.highlight pre .se { color: #cd0000 } /* Literal.String.Escape */
-.highlight pre .sh { color: #cd0000 } /* Literal.String.Heredoc */
-.highlight pre .si { color: #cd0000 } /* Literal.String.Interpol */
-.highlight pre .sx { color: #cd0000 } /* Literal.String.Other */
-.highlight pre .sr { color: #cd0000 } /* Literal.String.Regex */
-.highlight pre .s1 { color: #cd0000 } /* Literal.String.Single */
-.highlight pre .ss { color: #cd0000 } /* Literal.String.Symbol */
-.highlight pre .bp { color: #cd00cd } /* Name.Builtin.Pseudo */
-.highlight pre .vc { color: #00cdcd } /* Name.Variable.Class */
-.highlight pre .vg { color: #00cdcd } /* Name.Variable.Global */
-.highlight pre .vi { color: #00cdcd } /* Name.Variable.Instance */
-.highlight pre .il { color: #cd00cd } /* Literal.Number.Integer.Long */
+.highlight pre .hll, pre.code .hll { background-color: #222222 }
+.highlight pre, pre.code { background: #000000; color: #cccccc }
+.highlight pre .c, pre.code .c { color: #000080 } /* Comment */
+.highlight pre .err, pre.code .err { color: #cccccc; border: 1px solid #FF0000 } /* Error */
+.highlight pre .esc, pre.code .esc { color: #cccccc } /* Escape */
+.highlight pre .g, pre.code .g { color: #cccccc } /* Generic */
+.highlight pre .k, pre.code .k { color: #cdcd00 } /* Keyword */
+.highlight pre .l, pre.code .l { color: #cccccc } /* Literal */
+.highlight pre .n, pre.code .n { color: #cccccc } /* Name */
+.highlight pre .o, pre.code .o { color: #3399cc } /* Operator */
+.highlight pre .x, pre.code .x { color: #cccccc } /* Other */
+.highlight pre .p, pre.code .p { color: #cccccc } /* Punctuation */
+.highlight pre .cm, pre.code .cm { color: #000080 } /* Comment.Multiline */
+.highlight pre .cp, pre.code .cp { color: #000080 } /* Comment.Preproc */
+.highlight pre .c, pre.code .c1 { color: #000080 } /* Comment.Single */
+.highlight pre .cs, pre.code .cs { color: #cd0000; font-weight: bold } /* Comment.Special */
+.highlight pre .gd, pre.code .gd { color: #cd0000 } /* Generic.Deleted */
+.highlight pre .ge, pre.code .ge { color: #cccccc; font-style: italic } /* Generic.Emph */
+.highlight pre .gr, pre.code .gr { color: #FF0000 } /* Generic.Error */
+.highlight pre .gh, pre.code .gh { color: #000080; font-weight: bold } /* Generic.Heading */
+.highlight pre .gi, pre.code .gi { color: #00cd00 } /* Generic.Inserted */
+.highlight pre .go, pre.code .go { color: #888888 } /* Generic.Output */
+.highlight pre .gp, pre.code .gp { color: #000080; font-weight: bold } /* Generic.Prompt */
+.highlight pre .gs, pre.code .gs { color: #cccccc; font-weight: bold } /* Generic.Strong */
+.highlight pre .gu, pre.code .gu { color: #800080; font-weight: bold } /* Generic.Subheading */
+.highlight pre .gt, pre.code .gt { color: #0044DD } /* Generic.Traceback */
+.highlight pre .kc, pre.code .kc { color: #cdcd00 } /* Keyword.Constant */
+.highlight pre .kd, pre.code .kd { color: #00cd00 } /* Keyword.Declaration */
+.highlight pre .kn, pre.code .kn { color: #cd00cd } /* Keyword.Namespace */
+.highlight pre .kp, pre.code .kp { color: #cdcd00 } /* Keyword.Pseudo */
+.highlight pre .kr, pre.code .kr { color: #cdcd00 } /* Keyword.Reserved */
+.highlight pre .kt, pre.code .kt { color: #00cd00 } /* Keyword.Type */
+.highlight pre .ld, pre.code .ld { color: #cccccc } /* Literal.Date */
+.highlight pre .m, pre.code .m { color: #cd00cd } /* Literal.Number */
+.highlight pre .s, pre.code .s { color: #cd0000 } /* Literal.String */
+.highlight pre .na, pre.code .na { color: #cccccc } /* Name.Attribute */
+.highlight pre .nb, pre.code .nb { color: #cd00cd } /* Name.Builtin */
+.highlight pre .nc, pre.code .nc { color: #00cdcd } /* Name.Class */
+.highlight pre .no, pre.code .no { color: #cccccc } /* Name.Constant */
+.highlight pre .nd, pre.code .nd { color: #cccccc } /* Name.Decorator */
+.highlight pre .ni, pre.code .ni { color: #cccccc } /* Name.Entity */
+.highlight pre .ne, pre.code .ne { color: #666699; font-weight: bold } /* Name.Exception */
+.highlight pre .nf, pre.code .nf { color: #cccccc } /* Name.Function */
+.highlight pre .nl, pre.code .nl { color: #cccccc } /* Name.Label */
+.highlight pre .nn, pre.code .nn { color: #cccccc } /* Name.Namespace */
+.highlight pre .nx, pre.code .nx { color: #cccccc } /* Name.Other */
+.highlight pre .py, pre.code .py { color: #cccccc } /* Name.Property */
+.highlight pre .nt, pre.code .nt { color: #cccccc } /* Name.Tag */
+.highlight pre .nv, pre.code .nv { color: #00cdcd } /* Name.Variable */
+.highlight pre .ow, pre.code .ow { color: #cdcd00 } /* Operator.Word */
+.highlight pre .w, pre.code .w { color: #cccccc } /* Text.Whitespace */
+.highlight pre .mb, pre.code .mb { color: #cd00cd } /* Literal.Number.Bin */
+.highlight pre .mf, pre.code .mf { color: #cd00cd } /* Literal.Number.Float */
+.highlight pre .mh, pre.code .mh { color: #cd00cd } /* Literal.Number.Hex */
+.highlight pre .mi, pre.code .mi { color: #cd00cd } /* Literal.Number.Integer */
+.highlight pre .mo, pre.code .mo { color: #cd00cd } /* Literal.Number.Oct */
+.highlight pre .sb, pre.code .sb { color: #cd0000 } /* Literal.String.Backtick */
+.highlight pre .sc, pre.code .sc { color: #cd0000 } /* Literal.String.Char */
+.highlight pre .sd, pre.code .sd { color: #cd0000 } /* Literal.String.Doc */
+.highlight pre .s, pre.code .s2 { color: #cd0000 } /* Literal.String.Double */
+.highlight pre .se, pre.code .se { color: #cd0000 } /* Literal.String.Escape */
+.highlight pre .sh, pre.code .sh { color: #cd0000 } /* Literal.String.Heredoc */
+.highlight pre .si, pre.code .si { color: #cd0000 } /* Literal.String.Interpol */
+.highlight pre .sx, pre.code .sx { color: #cd0000 } /* Literal.String.Other */
+.highlight pre .sr, pre.code .sr { color: #cd0000 } /* Literal.String.Regex */
+.highlight pre .s, pre.code .s1 { color: #cd0000 } /* Literal.String.Single */
+.highlight pre .ss, pre.code .ss { color: #cd0000 } /* Literal.String.Symbol */
+.highlight pre .bp, pre.code .bp { color: #cd00cd } /* Name.Builtin.Pseudo */
+.highlight pre .vc, pre.code .vc { color: #00cdcd } /* Name.Variable.Class */
+.highlight pre .vg, pre.code .vg { color: #00cdcd } /* Name.Variable.Global */
+.highlight pre .vi, pre.code .vi { color: #00cdcd } /* Name.Variable.Instance */
+.highlight pre .il, pre.code .il { color: #cd00cd } /* Literal.Number.Integer.Long */

--- a/pelican-bootstrap3/static/css/pygments/vs.css
+++ b/pelican-bootstrap3/static/css/pygments/vs.css
@@ -1,34 +1,34 @@
-.highlight pre .hll { background-color: #ffffcc }
-.highlight pre  { background: #ffffff; }
-.highlight pre .c { color: #008000 } /* Comment */
-.highlight pre .err { border: 1px solid #FF0000 } /* Error */
-.highlight pre .k { color: #0000ff } /* Keyword */
-.highlight pre .cm { color: #008000 } /* Comment.Multiline */
-.highlight pre .cp { color: #0000ff } /* Comment.Preproc */
-.highlight pre .c1 { color: #008000 } /* Comment.Single */
-.highlight pre .cs { color: #008000 } /* Comment.Special */
-.highlight pre .ge { font-style: italic } /* Generic.Emph */
-.highlight pre .gh { font-weight: bold } /* Generic.Heading */
-.highlight pre .gp { font-weight: bold } /* Generic.Prompt */
-.highlight pre .gs { font-weight: bold } /* Generic.Strong */
-.highlight pre .gu { font-weight: bold } /* Generic.Subheading */
-.highlight pre .kc { color: #0000ff } /* Keyword.Constant */
-.highlight pre .kd { color: #0000ff } /* Keyword.Declaration */
-.highlight pre .kn { color: #0000ff } /* Keyword.Namespace */
-.highlight pre .kp { color: #0000ff } /* Keyword.Pseudo */
-.highlight pre .kr { color: #0000ff } /* Keyword.Reserved */
-.highlight pre .kt { color: #2b91af } /* Keyword.Type */
-.highlight pre .s { color: #a31515 } /* Literal.String */
-.highlight pre .nc { color: #2b91af } /* Name.Class */
-.highlight pre .ow { color: #0000ff } /* Operator.Word */
-.highlight pre .sb { color: #a31515 } /* Literal.String.Backtick */
-.highlight pre .sc { color: #a31515 } /* Literal.String.Char */
-.highlight pre .sd { color: #a31515 } /* Literal.String.Doc */
-.highlight pre .s2 { color: #a31515 } /* Literal.String.Double */
-.highlight pre .se { color: #a31515 } /* Literal.String.Escape */
-.highlight pre .sh { color: #a31515 } /* Literal.String.Heredoc */
-.highlight pre .si { color: #a31515 } /* Literal.String.Interpol */
-.highlight pre .sx { color: #a31515 } /* Literal.String.Other */
-.highlight pre .sr { color: #a31515 } /* Literal.String.Regex */
-.highlight pre .s1 { color: #a31515 } /* Literal.String.Single */
-.highlight pre .ss { color: #a31515 } /* Literal.String.Symbol */
+.highlight pre .hll, pre.code .hll { background-color: #ffffcc }
+.highlight pre, pre.code { background: #ffffff; }
+.highlight pre .c, pre.code .c { color: #008000 } /* Comment */
+.highlight pre .err, pre.code .err { border: 1px solid #FF0000 } /* Error */
+.highlight pre .k, pre.code .k { color: #0000ff } /* Keyword */
+.highlight pre .cm, pre.code .cm { color: #008000 } /* Comment.Multiline */
+.highlight pre .cp, pre.code .cp { color: #0000ff } /* Comment.Preproc */
+.highlight pre .c, pre.code .c1 { color: #008000 } /* Comment.Single */
+.highlight pre .cs, pre.code .cs { color: #008000 } /* Comment.Special */
+.highlight pre .ge, pre.code .ge { font-style: italic } /* Generic.Emph */
+.highlight pre .gh, pre.code .gh { font-weight: bold } /* Generic.Heading */
+.highlight pre .gp, pre.code .gp { font-weight: bold } /* Generic.Prompt */
+.highlight pre .gs, pre.code .gs { font-weight: bold } /* Generic.Strong */
+.highlight pre .gu, pre.code .gu { font-weight: bold } /* Generic.Subheading */
+.highlight pre .kc, pre.code .kc { color: #0000ff } /* Keyword.Constant */
+.highlight pre .kd, pre.code .kd { color: #0000ff } /* Keyword.Declaration */
+.highlight pre .kn, pre.code .kn { color: #0000ff } /* Keyword.Namespace */
+.highlight pre .kp, pre.code .kp { color: #0000ff } /* Keyword.Pseudo */
+.highlight pre .kr, pre.code .kr { color: #0000ff } /* Keyword.Reserved */
+.highlight pre .kt, pre.code .kt { color: #2b91af } /* Keyword.Type */
+.highlight pre .s, pre.code .s { color: #a31515 } /* Literal.String */
+.highlight pre .nc, pre.code .nc { color: #2b91af } /* Name.Class */
+.highlight pre .ow, pre.code .ow { color: #0000ff } /* Operator.Word */
+.highlight pre .sb, pre.code .sb { color: #a31515 } /* Literal.String.Backtick */
+.highlight pre .sc, pre.code .sc { color: #a31515 } /* Literal.String.Char */
+.highlight pre .sd, pre.code .sd { color: #a31515 } /* Literal.String.Doc */
+.highlight pre .s, pre.code .s2 { color: #a31515 } /* Literal.String.Double */
+.highlight pre .se, pre.code .se { color: #a31515 } /* Literal.String.Escape */
+.highlight pre .sh, pre.code .sh { color: #a31515 } /* Literal.String.Heredoc */
+.highlight pre .si, pre.code .si { color: #a31515 } /* Literal.String.Interpol */
+.highlight pre .sx, pre.code .sx { color: #a31515 } /* Literal.String.Other */
+.highlight pre .sr, pre.code .sr { color: #a31515 } /* Literal.String.Regex */
+.highlight pre .s, pre.code .s1 { color: #a31515 } /* Literal.String.Single */
+.highlight pre .ss, pre.code .ss { color: #a31515 } /* Literal.String.Symbol */

--- a/pelican-bootstrap3/static/css/pygments/xcode.css
+++ b/pelican-bootstrap3/static/css/pygments/xcode.css
@@ -1,57 +1,57 @@
-.highlight pre .hll { background-color: #ffffcc }
-.highlight pre  { background: #ffffff; }
-.highlight pre .c { color: #177500 } /* Comment */
-.highlight pre .err { color: #000000 } /* Error */
-.highlight pre .k { color: #A90D91 } /* Keyword */
-.highlight pre .l { color: #1C01CE } /* Literal */
-.highlight pre .n { color: #000000 } /* Name */
-.highlight pre .o { color: #000000 } /* Operator */
-.highlight pre .cm { color: #177500 } /* Comment.Multiline */
-.highlight pre .cp { color: #633820 } /* Comment.Preproc */
-.highlight pre .c1 { color: #177500 } /* Comment.Single */
-.highlight pre .cs { color: #177500 } /* Comment.Special */
-.highlight pre .kc { color: #A90D91 } /* Keyword.Constant */
-.highlight pre .kd { color: #A90D91 } /* Keyword.Declaration */
-.highlight pre .kn { color: #A90D91 } /* Keyword.Namespace */
-.highlight pre .kp { color: #A90D91 } /* Keyword.Pseudo */
-.highlight pre .kr { color: #A90D91 } /* Keyword.Reserved */
-.highlight pre .kt { color: #A90D91 } /* Keyword.Type */
-.highlight pre .ld { color: #1C01CE } /* Literal.Date */
-.highlight pre .m { color: #1C01CE } /* Literal.Number */
-.highlight pre .s { color: #C41A16 } /* Literal.String */
-.highlight pre .na { color: #836C28 } /* Name.Attribute */
-.highlight pre .nb { color: #A90D91 } /* Name.Builtin */
-.highlight pre .nc { color: #3F6E75 } /* Name.Class */
-.highlight pre .no { color: #000000 } /* Name.Constant */
-.highlight pre .nd { color: #000000 } /* Name.Decorator */
-.highlight pre .ni { color: #000000 } /* Name.Entity */
-.highlight pre .ne { color: #000000 } /* Name.Exception */
-.highlight pre .nf { color: #000000 } /* Name.Function */
-.highlight pre .nl { color: #000000 } /* Name.Label */
-.highlight pre .nn { color: #000000 } /* Name.Namespace */
-.highlight pre .nx { color: #000000 } /* Name.Other */
-.highlight pre .py { color: #000000 } /* Name.Property */
-.highlight pre .nt { color: #000000 } /* Name.Tag */
-.highlight pre .nv { color: #000000 } /* Name.Variable */
-.highlight pre .ow { color: #000000 } /* Operator.Word */
-.highlight pre .mb { color: #1C01CE } /* Literal.Number.Bin */
-.highlight pre .mf { color: #1C01CE } /* Literal.Number.Float */
-.highlight pre .mh { color: #1C01CE } /* Literal.Number.Hex */
-.highlight pre .mi { color: #1C01CE } /* Literal.Number.Integer */
-.highlight pre .mo { color: #1C01CE } /* Literal.Number.Oct */
-.highlight pre .sb { color: #C41A16 } /* Literal.String.Backtick */
-.highlight pre .sc { color: #2300CE } /* Literal.String.Char */
-.highlight pre .sd { color: #C41A16 } /* Literal.String.Doc */
-.highlight pre .s2 { color: #C41A16 } /* Literal.String.Double */
-.highlight pre .se { color: #C41A16 } /* Literal.String.Escape */
-.highlight pre .sh { color: #C41A16 } /* Literal.String.Heredoc */
-.highlight pre .si { color: #C41A16 } /* Literal.String.Interpol */
-.highlight pre .sx { color: #C41A16 } /* Literal.String.Other */
-.highlight pre .sr { color: #C41A16 } /* Literal.String.Regex */
-.highlight pre .s1 { color: #C41A16 } /* Literal.String.Single */
-.highlight pre .ss { color: #C41A16 } /* Literal.String.Symbol */
-.highlight pre .bp { color: #5B269A } /* Name.Builtin.Pseudo */
-.highlight pre .vc { color: #000000 } /* Name.Variable.Class */
-.highlight pre .vg { color: #000000 } /* Name.Variable.Global */
-.highlight pre .vi { color: #000000 } /* Name.Variable.Instance */
-.highlight pre .il { color: #1C01CE } /* Literal.Number.Integer.Long */
+.highlight pre .hll, pre.code .hll { background-color: #ffffcc }
+.highlight pre, pre.code { background: #ffffff; }
+.highlight pre .c, pre.code .c { color: #177500 } /* Comment */
+.highlight pre .err, pre.code .err { color: #000000 } /* Error */
+.highlight pre .k, pre.code .k { color: #A90D91 } /* Keyword */
+.highlight pre .l, pre.code .l { color: #1C01CE } /* Literal */
+.highlight pre .n, pre.code .n { color: #000000 } /* Name */
+.highlight pre .o, pre.code .o { color: #000000 } /* Operator */
+.highlight pre .cm, pre.code .cm { color: #177500 } /* Comment.Multiline */
+.highlight pre .cp, pre.code .cp { color: #633820 } /* Comment.Preproc */
+.highlight pre .c, pre.code .c1 { color: #177500 } /* Comment.Single */
+.highlight pre .cs, pre.code .cs { color: #177500 } /* Comment.Special */
+.highlight pre .kc, pre.code .kc { color: #A90D91 } /* Keyword.Constant */
+.highlight pre .kd, pre.code .kd { color: #A90D91 } /* Keyword.Declaration */
+.highlight pre .kn, pre.code .kn { color: #A90D91 } /* Keyword.Namespace */
+.highlight pre .kp, pre.code .kp { color: #A90D91 } /* Keyword.Pseudo */
+.highlight pre .kr, pre.code .kr { color: #A90D91 } /* Keyword.Reserved */
+.highlight pre .kt, pre.code .kt { color: #A90D91 } /* Keyword.Type */
+.highlight pre .ld, pre.code .ld { color: #1C01CE } /* Literal.Date */
+.highlight pre .m, pre.code .m { color: #1C01CE } /* Literal.Number */
+.highlight pre .s, pre.code .s { color: #C41A16 } /* Literal.String */
+.highlight pre .na, pre.code .na { color: #836C28 } /* Name.Attribute */
+.highlight pre .nb, pre.code .nb { color: #A90D91 } /* Name.Builtin */
+.highlight pre .nc, pre.code .nc { color: #3F6E75 } /* Name.Class */
+.highlight pre .no, pre.code .no { color: #000000 } /* Name.Constant */
+.highlight pre .nd, pre.code .nd { color: #000000 } /* Name.Decorator */
+.highlight pre .ni, pre.code .ni { color: #000000 } /* Name.Entity */
+.highlight pre .ne, pre.code .ne { color: #000000 } /* Name.Exception */
+.highlight pre .nf, pre.code .nf { color: #000000 } /* Name.Function */
+.highlight pre .nl, pre.code .nl { color: #000000 } /* Name.Label */
+.highlight pre .nn, pre.code .nn { color: #000000 } /* Name.Namespace */
+.highlight pre .nx, pre.code .nx { color: #000000 } /* Name.Other */
+.highlight pre .py, pre.code .py { color: #000000 } /* Name.Property */
+.highlight pre .nt, pre.code .nt { color: #000000 } /* Name.Tag */
+.highlight pre .nv, pre.code .nv { color: #000000 } /* Name.Variable */
+.highlight pre .ow, pre.code .ow { color: #000000 } /* Operator.Word */
+.highlight pre .mb, pre.code .mb { color: #1C01CE } /* Literal.Number.Bin */
+.highlight pre .mf, pre.code .mf { color: #1C01CE } /* Literal.Number.Float */
+.highlight pre .mh, pre.code .mh { color: #1C01CE } /* Literal.Number.Hex */
+.highlight pre .mi, pre.code .mi { color: #1C01CE } /* Literal.Number.Integer */
+.highlight pre .mo, pre.code .mo { color: #1C01CE } /* Literal.Number.Oct */
+.highlight pre .sb, pre.code .sb { color: #C41A16 } /* Literal.String.Backtick */
+.highlight pre .sc, pre.code .sc { color: #2300CE } /* Literal.String.Char */
+.highlight pre .sd, pre.code .sd { color: #C41A16 } /* Literal.String.Doc */
+.highlight pre .s, pre.code .s2 { color: #C41A16 } /* Literal.String.Double */
+.highlight pre .se, pre.code .se { color: #C41A16 } /* Literal.String.Escape */
+.highlight pre .sh, pre.code .sh { color: #C41A16 } /* Literal.String.Heredoc */
+.highlight pre .si, pre.code .si { color: #C41A16 } /* Literal.String.Interpol */
+.highlight pre .sx, pre.code .sx { color: #C41A16 } /* Literal.String.Other */
+.highlight pre .sr, pre.code .sr { color: #C41A16 } /* Literal.String.Regex */
+.highlight pre .s, pre.code .s1 { color: #C41A16 } /* Literal.String.Single */
+.highlight pre .ss, pre.code .ss { color: #C41A16 } /* Literal.String.Symbol */
+.highlight pre .bp, pre.code .bp { color: #5B269A } /* Name.Builtin.Pseudo */
+.highlight pre .vc, pre.code .vc { color: #000000 } /* Name.Variable.Class */
+.highlight pre .vg, pre.code .vg { color: #000000 } /* Name.Variable.Global */
+.highlight pre .vi, pre.code .vi { color: #000000 } /* Name.Variable.Instance */
+.highlight pre .il, pre.code .il { color: #1C01CE } /* Literal.Number.Integer.Long */

--- a/pelican-bootstrap3/static/css/pygments/zenburn.css
+++ b/pelican-bootstrap3/static/css/pygments/zenburn.css
@@ -1,70 +1,70 @@
-.highlight pre .hll { background-color: #2f2f2f }
-.highlight pre, .highlighttable pre { background: #3f3f3f; color: #dcdccc }
-.highlight pre .c { color: #7f9f7f } /* Comment */
-.highlight pre .err { color: #e37170; background-color: #3d3535 } /* Error */
-.highlight pre .g { color: #dcdccc } /* Generic */
-.highlight pre .k { color: #f0dfaf; font-weight: bold } /* Keyword */
-.highlight pre .l { color: #dcdccc } /* Literal */
-.highlight pre .n { color: #dcdccc } /* Name */
-.highlight pre .o { color: #dcdccc } /* Operator */
-.highlight pre .x { color: #dcdccc } /* Other */
-.highlight pre .p { color: #dcdccc } /* Punctuation */
-.highlight pre .cm { color: #6CA0A3 } /* Comment.Multiline */
-.highlight pre .cp { color: #94bff3 } /* Comment.Preproc */
-.highlight pre .c1 { color: #7f9f7f } /* Comment.Single */
-.highlight pre .cs { color: #7f9f7f } /* Comment.Special */
-.highlight pre .gd { color: #dcdccc } /* Generic.Deleted */
-.highlight pre .ge { color: #dcdccc } /* Generic.Emph */
-.highlight pre .gr { color: #dcdccc } /* Generic.Error */
-.highlight pre .gh { color: #dcdccc } /* Generic.Heading */
-.highlight pre .gi { color: #dcdccc } /* Generic.Inserted */
-.highlight pre .go { color: #dcdccc } /* Generic.Output */
-.highlight pre .gp { color: #dcdccc } /* Generic.Prompt */
-.highlight pre .gs { color: #dcdccc } /* Generic.Strong */
-.highlight pre .gu { color: #dcdccc } /* Generic.Subheading */
-.highlight pre .gt { color: #dcdccc } /* Generic.Traceback */
-.highlight pre .kc { color: #bfebbf } /* Keyword.Constant */
-.highlight pre .kd { color: #f0dfaf; font-weight: bold } /* Keyword.Declaration */
-.highlight pre .kn { color: #f0dfaf; font-weight: bold } /* Keyword.Namespace */
-.highlight pre .kp { color: #dcdccc; font-weight: bold } /* Keyword.Pseudo */
-.highlight pre .kr { color: #dcdccc; font-weight: bold } /* Keyword.Reserved */
-.highlight pre .kt { color: #7cb8bb } /* Keyword.Type */
-.highlight pre .ld { color: #dcdccc } /* Literal.Date */
-.highlight pre .m { color: #8cd0d3 } /* Literal.Number */
-.highlight pre .s { color: #cc9393 } /* Literal.String */
-.highlight pre .na { color: #dcdccc } /* Name.Attribute */
-.highlight pre .nb { color: #93e0e3 } /* Name.Builtin */
-.highlight pre .nc { color: #7cb8bb } /* Name.Class */
-.highlight pre .no { color: #dcdccc } /* Name.Constant */
-.highlight pre .nd { color: #efef8f } /* Name.Decorator */
-.highlight pre .ni { color: #dcdccc } /* Name.Entity */
-.highlight pre .ne { color: #ebed9f; font-weight: bold } /* Name.Exception */
-.highlight pre .nf { color: #8cd0d3 } /* Name.Function */
-.highlight pre .nl { color: #f0dfaf } /* Name.Label */
-.highlight pre .nn { color: #dcdccc } /* Name.Namespace */
-.highlight pre .nx { color: #dcdccc } /* Name.Other */
-.highlight pre .py { color: #dcdccc } /* Name.Property */
-.highlight pre .nt { color: #dcdccc } /* Name.Tag */
-.highlight pre .nv { color: #dfaf8f } /* Name.Variable */
-.highlight pre .ow { color: #f0dfaf; font-weight: bold } /* Operator.Word */
-.highlight pre .w { color: #dcdccc } /* Text.Whitespace */
-.highlight pre .mf { color: #dcdccc } /* Literal.Number.Float */
-.highlight pre .mh { color: #dcdccc } /* Literal.Number.Hex */
-.highlight pre .mi { color: #dcdccc } /* Literal.Number.Integer */
-.highlight pre .mo { color: #dcdccc } /* Literal.Number.Oct */
-.highlight pre .sb { color: #cc9393 } /* Literal.String.Backtick */
-.highlight pre .sc { color: #cc9393 } /* Literal.String.Char */
-.highlight pre .sd { color: #cc9393 } /* Literal.String.Doc */
-.highlight pre .s2 { color: #cc9393 } /* Literal.String.Double */
-.highlight pre .se { color: #cc9393 } /* Literal.String.Escape */
-.highlight pre .sh { color: #cc9393 } /* Literal.String.Heredoc */
-.highlight pre .si { color: #cc9393 } /* Literal.String.Interpol */
-.highlight pre .sx { color: #cc9393 } /* Literal.String.Other */
-.highlight pre .sr { color: #cc9393 } /* Literal.String.Regex */
-.highlight pre .s1 { color: #cc9393 } /* Literal.String.Single */
-.highlight pre .ss { color: #cc9393 } /* Literal.String.Symbol */
-.highlight pre .bp { color: #f0dfaf; font-weight: bold } /* Name.Builtin.Pseudo */
-.highlight pre .vc { color: #efef8f } /* Name.Variable.Class */
-.highlight pre .vg { color: #dcdccc } /* Name.Variable.Global */
-.highlight pre .vi { color: #dcdccc } /* Name.Variable.Instance */
-.highlight pre .il { color: #8cd0d3 } /* Literal.Number.Integer.Long */
+.highlight pre .hll, pre.code .hll { background-color: #2f2f2f }
+.highlight pre, pre.code, .highlighttable pre { background: #3f3f3f; color: #dcdccc }
+.highlight pre .c, pre.code .c { color: #7f9f7f } /* Comment */
+.highlight pre .err, pre.code .err { color: #e37170; background-color: #3d3535 } /* Error */
+.highlight pre .g, pre.code .g { color: #dcdccc } /* Generic */
+.highlight pre .k, pre.code .k { color: #f0dfaf; font-weight: bold } /* Keyword */
+.highlight pre .l, pre.code .l { color: #dcdccc } /* Literal */
+.highlight pre .n, pre.code .n { color: #dcdccc } /* Name */
+.highlight pre .o, pre.code .o { color: #dcdccc } /* Operator */
+.highlight pre .x, pre.code .x { color: #dcdccc } /* Other */
+.highlight pre .p, pre.code .p { color: #dcdccc } /* Punctuation */
+.highlight pre .cm, pre.code .cm { color: #6CA0A3 } /* Comment.Multiline */
+.highlight pre .cp, pre.code .cp { color: #94bff3 } /* Comment.Preproc */
+.highlight pre .c, pre.code .c1 { color: #7f9f7f } /* Comment.Single */
+.highlight pre .cs, pre.code .cs { color: #7f9f7f } /* Comment.Special */
+.highlight pre .gd, pre.code .gd { color: #dcdccc } /* Generic.Deleted */
+.highlight pre .ge, pre.code .ge { color: #dcdccc } /* Generic.Emph */
+.highlight pre .gr, pre.code .gr { color: #dcdccc } /* Generic.Error */
+.highlight pre .gh, pre.code .gh { color: #dcdccc } /* Generic.Heading */
+.highlight pre .gi, pre.code .gi { color: #dcdccc } /* Generic.Inserted */
+.highlight pre .go, pre.code .go { color: #dcdccc } /* Generic.Output */
+.highlight pre .gp, pre.code .gp { color: #dcdccc } /* Generic.Prompt */
+.highlight pre .gs, pre.code .gs { color: #dcdccc } /* Generic.Strong */
+.highlight pre .gu, pre.code .gu { color: #dcdccc } /* Generic.Subheading */
+.highlight pre .gt, pre.code .gt { color: #dcdccc } /* Generic.Traceback */
+.highlight pre .kc, pre.code .kc { color: #bfebbf } /* Keyword.Constant */
+.highlight pre .kd, pre.code .kd { color: #f0dfaf; font-weight: bold } /* Keyword.Declaration */
+.highlight pre .kn, pre.code .kn { color: #f0dfaf; font-weight: bold } /* Keyword.Namespace */
+.highlight pre .kp, pre.code .kp { color: #dcdccc; font-weight: bold } /* Keyword.Pseudo */
+.highlight pre .kr, pre.code .kr { color: #dcdccc; font-weight: bold } /* Keyword.Reserved */
+.highlight pre .kt, pre.code .kt { color: #7cb8bb } /* Keyword.Type */
+.highlight pre .ld, pre.code .ld { color: #dcdccc } /* Literal.Date */
+.highlight pre .m, pre.code .m { color: #8cd0d3 } /* Literal.Number */
+.highlight pre .s, pre.code .s { color: #cc9393 } /* Literal.String */
+.highlight pre .na, pre.code .na { color: #dcdccc } /* Name.Attribute */
+.highlight pre .nb, pre.code .nb { color: #93e0e3 } /* Name.Builtin */
+.highlight pre .nc, pre.code .nc { color: #7cb8bb } /* Name.Class */
+.highlight pre .no, pre.code .no { color: #dcdccc } /* Name.Constant */
+.highlight pre .nd, pre.code .nd { color: #efef8f } /* Name.Decorator */
+.highlight pre .ni, pre.code .ni { color: #dcdccc } /* Name.Entity */
+.highlight pre .ne, pre.code .ne { color: #ebed9f; font-weight: bold } /* Name.Exception */
+.highlight pre .nf, pre.code .nf { color: #8cd0d3 } /* Name.Function */
+.highlight pre .nl, pre.code .nl { color: #f0dfaf } /* Name.Label */
+.highlight pre .nn, pre.code .nn { color: #dcdccc } /* Name.Namespace */
+.highlight pre .nx, pre.code .nx { color: #dcdccc } /* Name.Other */
+.highlight pre .py, pre.code .py { color: #dcdccc } /* Name.Property */
+.highlight pre .nt, pre.code .nt { color: #dcdccc } /* Name.Tag */
+.highlight pre .nv, pre.code .nv { color: #dfaf8f } /* Name.Variable */
+.highlight pre .ow, pre.code .ow { color: #f0dfaf; font-weight: bold } /* Operator.Word */
+.highlight pre .w, pre.code .w { color: #dcdccc } /* Text.Whitespace */
+.highlight pre .mf, pre.code .mf { color: #dcdccc } /* Literal.Number.Float */
+.highlight pre .mh, pre.code .mh { color: #dcdccc } /* Literal.Number.Hex */
+.highlight pre .mi, pre.code .mi { color: #dcdccc } /* Literal.Number.Integer */
+.highlight pre .mo, pre.code .mo { color: #dcdccc } /* Literal.Number.Oct */
+.highlight pre .sb, pre.code .sb { color: #cc9393 } /* Literal.String.Backtick */
+.highlight pre .sc, pre.code .sc { color: #cc9393 } /* Literal.String.Char */
+.highlight pre .sd, pre.code .sd { color: #cc9393 } /* Literal.String.Doc */
+.highlight pre .s, pre.code .s2 { color: #cc9393 } /* Literal.String.Double */
+.highlight pre .se, pre.code .se { color: #cc9393 } /* Literal.String.Escape */
+.highlight pre .sh, pre.code .sh { color: #cc9393 } /* Literal.String.Heredoc */
+.highlight pre .si, pre.code .si { color: #cc9393 } /* Literal.String.Interpol */
+.highlight pre .sx, pre.code .sx { color: #cc9393 } /* Literal.String.Other */
+.highlight pre .sr, pre.code .sr { color: #cc9393 } /* Literal.String.Regex */
+.highlight pre .s, pre.code .s1 { color: #cc9393 } /* Literal.String.Single */
+.highlight pre .ss, pre.code .ss { color: #cc9393 } /* Literal.String.Symbol */
+.highlight pre .bp, pre.code .bp { color: #f0dfaf; font-weight: bold } /* Name.Builtin.Pseudo */
+.highlight pre .vc, pre.code .vc { color: #efef8f } /* Name.Variable.Class */
+.highlight pre .vg, pre.code .vg { color: #dcdccc } /* Name.Variable.Global */
+.highlight pre .vi, pre.code .vi { color: #dcdccc } /* Name.Variable.Instance */
+.highlight pre .il, pre.code .il { color: #8cd0d3 } /* Literal.Number.Integer.Long */


### PR DESCRIPTION
While markdown puts code inside div blocks with the "highlight"
class, restructedText puts code blocks inside pre tags with the
"code" class.