### PR TITLE
Insert a summary in the sidebar to display on all the pages.

### DIFF
--- a/gum/templates/sidebar.html
+++ b/gum/templates/sidebar.html
@@ -19,8 +19,8 @@
   {% endif %}
   </ul>
 
-{% if categories and categories|length > 1 %}
 <h4>Categories</h4>
+{% if categories %}
 <ul class="blank">
 	{% for cat, null in categories %}
 		<li><a href="{{ SITEURL }}/{{ cat.url|e }}">{{ cat }}</a></li>

--- a/gum/templates/sidebar.html
+++ b/gum/templates/sidebar.html
@@ -19,8 +19,8 @@
   {% endif %}
   </ul>
 
+{% if categories and categories|length > 1 %}
 <h4>Categories</h4>
-{% if categories %}
 <ul class="blank">
 	{% for cat, null in categories %}
 		<li><a href="{{ SITEURL }}/{{ cat.url|e }}">{{ cat }}</a></li>

--- a/pelican-bootstrap3/README.md
+++ b/pelican-bootstrap3/README.md
@@ -385,6 +385,20 @@ Originally developed for including certification marks in your sidebar. E.g.,
 
 http://dmark.github.io
 
+### Sidebar Summary
+
+Include a text to the top of the sidebar. Useful to display a summary of your site on all the pages.
+
+```
+SIDE_SUMMARY_TITLE = "WHAT is your quest ?"  # Title to display
+SIDE_SUMMARY_ICON = "flash"  # If you want to add an icon to the title
+SIDE_SUMMARY_URL = "to_seek_the_holy_grail.html"  # If you want the title to target a page
+SIDE_SUMMARY = """
+Sir Bedevere: How do you know so much about swallows?
+<br>King Arthur: Well, you have to know these things when you're king, y'know. 
+""""
+```
+
 ### Translations
 
 This template can be translated using pybabel and the enclosed Makefile. See

--- a/pelican-bootstrap3/templates/includes/sidebar.html
+++ b/pelican-bootstrap3/templates/includes/sidebar.html
@@ -2,6 +2,7 @@
 <section class="well well-sm">
   <ul class="list-group list-group-flush">
     {% include 'includes/sidebar/optional_top.html' ignore missing %}
+    {% include 'includes/sidebar/summary.html' %}
     {% include 'includes/sidebar/social.html' %}
     {% include 'includes/sidebar/recent_posts.html' %}
     {% include 'includes/sidebar/categories.html' %}

--- a/pelican-bootstrap3/templates/includes/sidebar/summary.html
+++ b/pelican-bootstrap3/templates/includes/sidebar/summary.html
@@ -1,0 +1,11 @@
+{% from 'includes/sidebar/macros.jinja' import title %}
+
+{% if SIDE_SUMMARY %}
+<font class="list-group-item">
+    {% if SIDE_SUMMARY_TITLE %}
+        <a href="{{ SITEURL }}/{{ SIDE_SUMMARY_URL }}"><h4>{{
+                title(_(SIDE_SUMMARY_TITLE), DISABLE_SIDEBAR_TITLE_ICONS, icon=SIDE_SUMMARY_ICON) }}</h4></a>
+    {% endif %}
+    <font class="summary_text">{{ SIDE_SUMMARY }}</font>
+</font>
+{% endif %}


### PR DESCRIPTION
Allows to display a small text on the whole site, for example a summary of the author, with a link on a more detailed page.