### PR TITLE
Graymill: Change 'pages' variable to lower-case

### DIFF
--- a/graymill/templates/base.html
+++ b/graymill/templates/base.html
@@ -61,7 +61,7 @@
                 <li><a href="{{ link }}">{{ title }}</a></li>
         {% endfor %}
 
-        {% if DISPLAY_PAGES_ON_MENU and PAGES %}
+        {% if DISPLAY_PAGES_ON_MENU and pages %}
             {% for p in pages %}
                 <li><a href="{{ SITEURL }}/{{ p.url }}">{{ p.title }}</a></li>
             {% endfor %}


### PR DESCRIPTION
Fixes the uppercase 'PAGES' variable (which has now been discontinued).
Pelican made a recent change and now requires lowercase 'pages':
http://docs.getpelican.com/en/stable/faq.html#since-i-upgraded-pelican-my-pages-are-no-longer-rendered