### PR TITLE
Fix mnmlist theme`loop` build error

### DIFF
--- a/mnmlist/templates/index.html
+++ b/mnmlist/templates/index.html
@@ -23,11 +23,11 @@
         {% else %} 
             <li><a href="{{ SITEURL }}/{{ article.url }}" rel="bookmark" title="Permalink to {{ article.title|striptags }}">{{ article.title }}</a></li>
         {% endif %}
-{% endfor %}
-    {% if loop.length > 1 %}
-    </ol>
-    </section><!-- #article-list -->
-{% endif %}
+        {% if loop.length > 1 %}
+            </ol>
+            </section><!-- #article-list -->
+        {% endif %}
+    {% endfor %}
 {% else %}
     No posts found.
 {% endif %}


### PR DESCRIPTION
Fixes this error:
```
pelican /path/to/blog/content -o /path/to/blog/output -s /path/to/blog/pelicanconf.py 
CRITICAL: UndefinedError: 'loop' is undefined
make: *** [Makefile:65: html] Error 1
```
using the mnmlist theme.

CC: @justinmayer 