### PR TITLE
pelican-bootstrap3: Fix Disqus bug #581 

### DIFF
--- a/pelican-bootstrap3/templates/includes/comments.html
+++ b/pelican-bootstrap3/templates/includes/comments.html
@@ -8,20 +8,24 @@
             /* * * CONFIGURATION VARIABLES: EDIT BEFORE PASTING INTO YOUR WEBPAGE * * */
             var disqus_shortname = '{{ DISQUS_SITENAME }}'; // required: replace example with your forum shortname
 
-            {% if article %}
-                {% if not DISQUS_NO_ID %}
-                    var disqus_identifier = '{{ article.date|strftime('%Y-%m-') ~ article.slug if DISQUS_ID_PREFIX_SLUG else article.slug }}';
-                {% endif %}
-                var disqus_url = '{{ SITEURL }}/{{ article.url }}';
-            {% elif page %}
-                {% if not DISQUS_NO_ID %}
-                    var disqus_identifier = 'page-{{ page.slug }}';
-                {% endif %}
-                var disqus_url = '{{ SITEURL }}/{{ page.url }}';
-            {% endif %}
-
             var disqus_config = function () {
                 this.language = "{{ DEFAULT_LANG }}";
+
+                {% if article %}
+                    {% if not DISQUS_NO_ID %}
+                        this.page.identifier = '{{ article.date|strftime('%Y-%m-%d-') ~ article.slug }}';
+                    {% endif %}
+                    {% if SITEURL %}
+                        this.page.url = '{{ SITEURL }}/{{ article.url }}';
+                    {% endif %}
+                {% elif page %}
+                    {% if not DISQUS_NO_ID %}
+                        this.page.identifier = 'page-{{ page.slug }}';
+                    {% endif %}
+                    {% if SITEURL %}
+                        this.page.url = '{{ SITEURL }}/{{ page.url }}';
+                    {% endif %}
+                {% endif %}
             };
 
             /* * * DON'T EDIT BELOW THIS LINE * * */


### PR DESCRIPTION
Update the DISQUS "disqus_config" function code style as the example on <https://help.disqus.com/customer/portal/articles/472098-javascript-configuration-variables>.

The "page.identifier" variable always be formatting to "%Y-%m-%d-slug", because an ID conflict may occur while two articles in different categories have the same slug.(<https://help.disqus.com/customer/portal/articles/662547-why-are-the-same-comments-showing-up-on-multiple-pages->) Although article metadata "date" is not mandatory, but it causes an error when it is non-existent, maybe it is used somewhere else.

The "page.url" variable is specified only when "SITEURL" exists( <https://help.disqus.com/customer/portal/articles/472098-javascript-configuration-variables#thispageurl>):

> Please note that an absolute URL is required for the this.page.url variable. Using a relative URL for this variable may prevent Disqus from loading successfully on the page.