### PR TITLE
Add pelican-bootstrap3 option for sidebar pages

### DIFF
--- a/pelican-bootstrap3/README.md
+++ b/pelican-bootstrap3/README.md
@@ -262,6 +262,7 @@ icon to show. You can provide an alternative icon string as the third string (as
 	* Set `DISPLAY_TAGS_INLINE` to _True_, to display the tags inline (ie. as tagcloud)
 	* Set `TAGS_URL` to the relative URL of the tags index page (typically `tags.html`)
 * **Categories** will be shown if `DISPLAY_CATEGORIES_ON_SIDEBAR` is set to _True_
+* **Pages** will be listed if `DISPLAY_PAGES_ON_SIDEBAR` is set to _True_
 * **Recent Posts** will be shown if `DISPLAY_RECENT_POSTS_ON_SIDEBAR` is set to _True_
 	* Use `RECENT_POST_COUNT` to control the amount of recent posts. Defaults to **5**
 * **Archive** will be shown if `DISPLAY_ARCHIVE_ON_SIDEBAR` is set to _True_ and `MONTH_ARCHIVE_SAVE_AS` is set up properly.

--- a/pelican-bootstrap3/templates/includes/sidebar.html
+++ b/pelican-bootstrap3/templates/includes/sidebar.html
@@ -4,6 +4,7 @@
     {% include 'includes/sidebar/optional_top.html' ignore missing %}
     {% include 'includes/sidebar/social.html' %}
     {% include 'includes/sidebar/recent_posts.html' %}
+    {% include 'includes/sidebar/pages.html' %}
     {% include 'includes/sidebar/categories.html' %}
     {% include 'includes/sidebar/tag_cloud.html' %}
     {% include 'includes/sidebar/show_source.html' %}

--- a/pelican-bootstrap3/templates/includes/sidebar/page-li.html
+++ b/pelican-bootstrap3/templates/includes/sidebar/page-li.html
@@ -1,0 +1,1 @@
+<a href="{{ SITEURL }}/{{ page.url }}">{{ page.menulabel|default(page.title) }}</a>

--- a/pelican-bootstrap3/templates/includes/sidebar/pages.html
+++ b/pelican-bootstrap3/templates/includes/sidebar/pages.html
@@ -1,0 +1,16 @@
+{% if DISPLAY_PAGES_ON_SIDEBAR %}
+  {% from 'includes/sidebar/macros.jinja' import title %}
+
+<!-- Sidebar/Pages -->
+<li class="list-group-item">
+  <h4>{{ title(_('Pages')) }}</h4>
+  <ul class="list-group" id="pages">
+    {% for page in pages %}
+    <li class="list-group-item">
+      {%- include 'includes/sidebar/page-li.html' -%}
+    </li>
+    {% endfor %}
+  </ul>
+</li>
+<!-- End Sidebar/Pages -->
+{% endif %}


### PR DESCRIPTION
New option for pelican-bootstrap3 theme DISPLAY_PAGES_ON_SIDEBAR allows showing list of pages on the sidebar, similar to the way list of recent posts or categories can be shown in the sidebar.

Sometimes I want to list my site pages in the sidebar.  This change adds a new option for pelican-bootstrap3 theme.  It has no effect on existing sites if the new option is not defined or set to False.