### PR TITLE
Update svbhack theme url

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -57,7 +57,7 @@
 	url = https://github.com/erfaan/pelican-theme-irfan.git
 [submodule "svbhack"]
 	path = svbhack
-	url = https://github.com/giulivo/pelican-svbhack.git
+	url = https://github.com/gfidente/pelican-svbhack.git
 [submodule "html5-dopetrope"]
 	path = html5-dopetrope
 	url = https://github.com/PierrePaul/html5-dopetrope.git


### PR DESCRIPTION
The old url still works thanks to github redirection but the repo
is now hosted at a different url.