### PR TITLE
Fix link for MathJax source

### DIFF
--- a/pelican-bootstrap3/templates/includes/liquid_tags_nb_header.html
+++ b/pelican-bootstrap3/templates/includes/liquid_tags_nb_header.html
@@ -143,7 +143,7 @@ div.collapseheader {
 
 </style>
 
-<script src="https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS_HTML" type="text/javascript"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.0/MathJax.js?config=TeX-AMS_HTML" type="text/javascript"></script>
 <script type="text/javascript">
 init_mathjax = function() {
     if (window.MathJax) {


### PR DESCRIPTION
It turns out that the theme was using an older version of the mathjax source
src="https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS_HTML"
which should be:
src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.0/MathJax.js?config=TeX-AMS_HTML"

See news [here](https://www.mathjax.org/cdn-shutting-down/).