### PR TITLE
add ABOUT_ME_HEADER variable to pelican-bootstrap3 theme

### DIFF
--- a/pelican-bootstrap3/static/css/style.css
+++ b/pelican-bootstrap3/static/css/style.css
@@ -242,3 +242,12 @@ figure.floatcenter, .align-center {
 .gap-left {
   margin-left: 10px;
 }
+
+/* Hide the `In: []` and `Out: []` stuff from jupyter notebooks */
+.prompt {
+    display: none;
+}
+
+.collapseheader.inner_cell {
+    background-color: rgb(211, 211, 211);
+}

--- a/pelican-bootstrap3/static/css/style.css
+++ b/pelican-bootstrap3/static/css/style.css
@@ -248,6 +248,43 @@ figure.floatcenter, .align-center {
     display: none;
 }
 
+/* Gray background for Collapse/Expand button */
 .collapseheader.inner_cell {
     background-color: rgb(211, 211, 211);
+}
+
+.inner_cell pre {
+    /* Turn off border in expanded code */
+    border-style: none;
+    /* Turn off big gap in bottom of code blocks */
+    margin-bottom: 0;
+}
+
+/* Class to turn off link underline */
+/* .entry-content a.nounderline, .entry-content a.nounderline:hover { */
+a.nounderline, a.nounderline:hover {
+    text-decoration: none;
+    border-bottom: none;
+}
+
+/* Nice padding for article tags */
+button.tag-btn {
+    padding-top: 3px;
+    padding-right: 6px;
+    padding-bottom: 3px;
+    padding-left: 6px;
+    margin-top: 4px;
+    margin-right: 2px;
+    margin-bottom: 4px;
+    margin-left: 2px;
+    background-color: #f8f8f8;
+}
+
+button.tag-btn:hover {
+    background-color: #eee;
+}
+
+/* Hacky class to add blank divs for vertical space in html */
+.spacer {
+    height: 10px;
 }

--- a/pelican-bootstrap3/static/css/style.css
+++ b/pelican-bootstrap3/static/css/style.css
@@ -4,6 +4,9 @@ body {
 
 #sidebar .list-group, #sidebar .list-group-item {
     background-color: transparent;
+    /* Tighter spacing between social and tags entries in sidebar */
+    padding-top: 5px;
+    padding-bottom: 5px;
 }
 
 /* for list-groups nested within a list-group-item, reset the bottom margin */

--- a/pelican-bootstrap3/templates/article.html
+++ b/pelican-bootstrap3/templates/article.html
@@ -80,11 +80,12 @@
                 </h1>
             </header>
             <div class="entry-content">
-                <div class="panel">
-                    <div class="panel-body">
+                <!-- <div class="panel"> -->
+                <!--     <div class="panel-body"> -->
                         {% include "includes/article_info.html" %}
-                    </div>
-                </div>
+                    <!-- </div> -->
+                <!-- </div> -->
+                {% include 'includes/series.html' %}
                 {{ article.content }}
             </div>
             <!-- /.entry-content -->

--- a/pelican-bootstrap3/templates/article_list.html
+++ b/pelican-bootstrap3/templates/article_list.html
@@ -5,13 +5,11 @@
             <article>
                 <h2><a href="{{ SITEURL }}/{{ article.url }}">{{ article.title }}</a></h2>
                 {% if DISPLAY_ARTICLE_INFO_ON_INDEX %}
-                    <div class="well well-sm">
-                        {% include "includes/article_info.html" %}
-                    </div>
+                    {% include "includes/article_info.html" %}
                 {% endif %}
                 <div class="summary">{{ article.summary }}
                     {% include 'includes/comment_count.html' %}
-                    <a class="btn btn-info" href="{{ SITEURL }}/{{ article.url }}">{{ _('more') }} ...</a>
+                    <a class="btn btn-primary" href="{{ SITEURL }}/{{ article.url }}">{{ _('more') }} ...</a>
                 </div>
             </article>
             <hr/>

--- a/pelican-bootstrap3/templates/article_list.html
+++ b/pelican-bootstrap3/templates/article_list.html
@@ -11,7 +11,7 @@
                 {% endif %}
                 <div class="summary">{{ article.summary }}
                     {% include 'includes/comment_count.html' %}
-                    <a class="btn btn-default btn-xs" href="{{ SITEURL }}/{{ article.url }}">{{ _('more') }} ...</a>
+                    <a class="btn btn-info" href="{{ SITEURL }}/{{ article.url }}">{{ _('more') }} ...</a>
                 </div>
             </article>
             <hr/>

--- a/pelican-bootstrap3/templates/base.html
+++ b/pelican-bootstrap3/templates/base.html
@@ -222,7 +222,7 @@
     <script src="{{ SITEURL }}/{{ THEME_STATIC_DIR }}/js/bodypadding.js"></script>
 {% endif %}
 {% include 'includes/sidebar/github-js.html' %}
-{% include 'includes/disqus_script.html' %}
+<!-- include 'includes/disqus_script.html' -->
 {% include 'includes/ga.html' %}
 {% include 'includes/piwik.html' %}
 

--- a/pelican-bootstrap3/templates/includes/aboutme.html
+++ b/pelican-bootstrap3/templates/includes/aboutme.html
@@ -6,7 +6,13 @@
     {% endif %}
     {% if ABOUT_ME %}
     <p>
-      <strong>{{ _('About') }} {{ AUTHOR }}</strong><br/>
+        {% if ABOUT_ME_HEADER is defined %}
+            {% if ABOUT_ME_HEADER %}
+                <strong>{{ ABOUT_ME_HEADER }}</strong><br/>
+            {% endif %}
+        {% else %}
+            <strong>{{ _('About') }} {{ AUTHOR }}</strong><br/>
+        {% endif %}
         {{ ABOUT_ME }}
     </p>
     {% endif %}

--- a/pelican-bootstrap3/templates/includes/article_info.html
+++ b/pelican-bootstrap3/templates/includes/article_info.html
@@ -1,16 +1,25 @@
-<footer class="post-info">
-    <span class="label label-default">Date</span>
-    <span class="published">
-        <i class="fa fa-calendar"></i><time datetime="{{ article.date.isoformat() }}"> {{ article.locale_date }}</time>
-    </span>
-    {% if SHOW_DATE_MODIFIED %}
-        {% if article.modified %}
-          <span class="label label-default">{{ _('Modified') }}</span>
-            <span class="modified">
-                <i class="fa fa-calendar"></i><time datetime="{{ article.modified.isoformat() }}"> {{ article.locale_modified }}</time>
-            </span>
-        {% endif %}
-    {% endif %}
+<footer class="post-info row">
+  <div class="col-sm-12">
+    <time class="published" datetime="{{ article.date.isoformat() }}">
+      {{ article.locale_date }}
+    </time>
+    &nbsp; | &nbsp;
+    <a href="{{ SITEURL }}/{{ article.category.url }}"><i class="fa fa-folder-open"></i> {{ article.category }}</a>
+  </div>
+  <div class="spacer"></div>
+
+    <!-- <span class="label label-default">Date</span> -->
+    <!-- <span class="published"> -->
+    <!--     <i class="fa fa-calendar"></i><time datetime="{{ article.date.isoformat() }}"> {{ article.locale_date }}</time> -->
+    <!-- </span> -->
+    <!-- {% if SHOW_DATE_MODIFIED %} -->
+    <!--     {% if article.modified %} -->
+    <!--       <span class="label label-default">{{ _('Modified') }}</span> -->
+    <!--         <span class="modified"> -->
+    <!--             <i class="fa fa-calendar"></i><time datetime="{{ article.modified.isoformat() }}"> {{ article.locale_modified }}</time> -->
+    <!--         </span> -->
+    <!--     {% endif %} -->
+    <!-- {% endif %} -->
 
     {% if SHOW_SERIES %}
         {% if article.series %}
@@ -37,7 +46,10 @@
         </span>
     {% endif %}
 
-    {% include 'includes/taglist.html' %}
+    <div class="col-sm-12">
+      {% include 'includes/taglist.html' %}
+    </div>
     {% import 'includes/translations.html' as translations with context %}
     {{ translations.translations_for(article) }}
+    <div class="col-sm-12 spacer"></div>
 </footer><!-- /.post-info -->

--- a/pelican-bootstrap3/templates/includes/comments.html
+++ b/pelican-bootstrap3/templates/includes/comments.html
@@ -12,12 +12,12 @@
                 {% if not DISQUS_NO_ID %}
                     var disqus_identifier = '{{ article.date|strftime('%Y-%m-') ~ article.slug if DISQUS_ID_PREFIX_SLUG else article.slug }}';
                 {% endif %}
-                var disqus_url = '{{ SITEURL }}/{{ article.url }}';
+                var disqus_url = 'https://benjlindsay.com/{{ article.url }}';
             {% elif page %}
                 {% if not DISQUS_NO_ID %}
                     var disqus_identifier = 'page-{{ page.slug }}';
                 {% endif %}
-                var disqus_url = '{{ SITEURL }}/{{ page.url }}';
+                var disqus_url = 'https://benjlindsay.com/{{ page.url }}';
             {% endif %}
 
             var disqus_config = function () {

--- a/pelican-bootstrap3/templates/includes/comments.html
+++ b/pelican-bootstrap3/templates/includes/comments.html
@@ -29,13 +29,13 @@
                 var dsq = document.createElement('script');
                 dsq.type = 'text/javascript';
                 dsq.async = true;
-                dsq.src = '//' + disqus_shortname + '.disqus.com/embed.js';
+                dsq.src = 'https://' + disqus_shortname + '.disqus.com/embed.js';
                 (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);
             })();
         </script>
-        <noscript>Please enable JavaScript to view the <a href="http://disqus.com/?ref_noscript">comments powered by
+        <noscript>Please enable JavaScript to view the <a href="https://disqus.com/?ref_noscript">comments powered by
             Disqus.</a></noscript>
-        <a href="http://disqus.com" class="dsq-brlink">comments powered by <span class="logo-disqus">Disqus</span></a>
+        <a href="https://disqus.com" class="dsq-brlink">comments powered by <span class="logo-disqus">Disqus</span></a>
 
     </section>
 {% endif %}

--- a/pelican-bootstrap3/templates/includes/disqus_script.html
+++ b/pelican-bootstrap3/templates/includes/disqus_script.html
@@ -12,7 +12,7 @@
         */
         (function() { // DON'T EDIT BELOW THIS LINE
             var d = document, s = d.createElement('script');
-            s.src = '//{{ DISQUS_SITENAME }}.disqus.com/embed.js';
+            s.src = 'https://{{ DISQUS_SITENAME }}.disqus.com/embed.js';
             s.setAttribute('data-timestamp', +new Date());
             (d.head || d.body).appendChild(s);
         })();

--- a/pelican-bootstrap3/templates/includes/disqus_script.html
+++ b/pelican-bootstrap3/templates/includes/disqus_script.html
@@ -1,17 +1,21 @@
 {% if DISQUS_SITENAME %}
     <!-- Disqus -->
-    <script type="text/javascript">
-        /* * * CONFIGURATION VARIABLES: EDIT BEFORE PASTING INTO YOUR WEBPAGE * * */
-        var disqus_shortname = '{{ DISQUS_SITENAME }}'; // required: replace example with your forum shortname
-
-        /* * * DON'T EDIT BELOW THIS LINE * * */
-        (function () {
-            var s = document.createElement('script');
-            s.async = true;
-            s.type = 'text/javascript';
-            s.src = '//' + disqus_shortname + '.disqus.com/count.js';
-            (document.getElementsByTagName('HEAD')[0] || document.getElementsByTagName('BODY')[0]).appendChild(s);
-        }());
+    <script>
+        /**
+        *  RECOMMENDED CONFIGURATION VARIABLES: EDIT AND UNCOMMENT THE SECTION BELOW TO INSERT DYNAMIC VALUES FROM YOUR PLATFORM OR CMS.
+        *  LEARN WHY DEFINING THESE VARIABLES IS IMPORTANT: https://disqus.com/admin/universalcode/#configuration-variables*/
+        /*
+        var disqus_config = function () {
+        this.page.url = PAGE_URL;  // Replace PAGE_URL with your page's canonical URL variable
+        this.page.identifier = PAGE_IDENTIFIER; // Replace PAGE_IDENTIFIER with your page's unique identifier variable
+        };
+        */
+        (function() { // DON'T EDIT BELOW THIS LINE
+            var d = document, s = d.createElement('script');
+            s.src = '//{{ DISQUS_SITENAME }}.disqus.com/embed.js';
+            s.setAttribute('data-timestamp', +new Date());
+            (d.head || d.body).appendChild(s);
+        })();
     </script>
     <!-- End Disqus Code -->
 {% endif %}

--- a/pelican-bootstrap3/templates/includes/taglist.html
+++ b/pelican-bootstrap3/templates/includes/taglist.html
@@ -1,9 +1,9 @@
 {% if article.tags %}
-<span class="label label-default">{{ _('Tags') }}</span>
 {% for tag in article.tags %}
-	<a href="{{ SITEURL }}/{{ tag.url }}">{{ tag }}</a>
-    {% if not loop.last %}
-        /
-    {% endif %}
+<a href="{{ SITEURL }}/{{ tag.url }}" class="nounderline">
+  <button type="button" class="btn tag-btn">
+    {{ tag }}
+  </button>
+</a>
 {% endfor %}
 {% endif %}


### PR DESCRIPTION
I added support for a variable `ABOUT_ME_HEADER`, where if the variable doesn't exist, the default behavior ("About <Author>" printed above the `ABOUT_ME` content. If it's `False`, or an empty string, then nothing is printed above the `ABOUT_ME` content. If it's a non-empty string, that string is used as the header above the `ABOUT_ME` content.