### PR TITLE
Using HTTPS for Brutalist submodule instead of SSH

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -252,4 +252,4 @@
 	url = https://github.com/oulenz/pelican-grid-focus.git
 [submodule "brutalist"]
 	path = brutalist
-	url = git@github.com:mamcmanus/brutalist.git
+	url = https://github.com/mamcmanus/brutalist.git


### PR DESCRIPTION
Should fix issue that was breaking the auto-build.