### PR TITLE
Remove two more articles|sort constructs

### DIFF
--- a/uikit/templates/articles.html
+++ b/uikit/templates/articles.html
@@ -12,7 +12,7 @@
 <h1>{{'all the articles'|capitalize}}</h1>
 
 <ul>
-{% for article in articles|sort %}
+{% for article in articles %}
     <li><a class="{% if CAPITALIZE_HEADINGS %}capitalize{% endif %}" href="/{{ article.url }}">{{ article.title }}</a></li>
 {% endfor %}
 </ul>

--- a/zurb-F5-basic/templates/tags.html
+++ b/zurb-F5-basic/templates/tags.html
@@ -2,7 +2,7 @@
 {% block content %}
 
 <ul class="circle">
-    {% for tag, articles in tags|sort %}
+    {% for tag, articles in tags %}
 	<li><a href="{{ SITEURL }}/{{ tag.url }}">{{ tag }}</a></li>
 	<ul class="square">
 	{% for article in articles %}


### PR DESCRIPTION
This is the issue getpelican/pelican-themes#483 which was supposed to be fixed by #506 (and commit f1a4bba40281fa21816d6619d32136fc6a8f086d), but two occurrences of the problem were missed.

Basically, as https://github.com/getpelican/pelican/issues/1591#issuecomment-70272693 says:

> For future reference: Don't use sort in templates on articles.