### PR TITLE
cebong: Removed unused font imports

### DIFF
--- a/cebong/static/css/main.css
+++ b/cebong/static/css/main.css
@@ -11,9 +11,8 @@
 @import url("reset.css");
 @import url("pygment.css");
 @import url("typogrify.css");
-@import url(https://fonts.googleapis.com/css?family=Yanone+Kaffeesatz&subset=latin);
-@import url(https://fonts.googleapis.com/css?family=Crimson+Text:400,400italic,600,600italic,700,700italic);
-@import url(https://fonts.googleapis.com/css?family=Droid+Sans+Mono);
+@import url("https://fonts.googleapis.com/css?family=Crimson+Text:400,400italic,600,600italic,700,700italic");
+
 /***** Global *****/
 /* Body */
 body {
@@ -58,7 +57,7 @@ h1, h2, h3, h4, h5, h6 {
     font-style: normal;
 	line-height: 50px;
 	/*margin-bottom: .8em;*/
-    font-family: 'Crimson Text', 'Yanone Kaffeesatz', arial, serif;
+    font-family: 'Crimson Text', arial, serif;
 }
 h1 {
     font-size: 50px;


### PR DESCRIPTION
It just adds to network roundtrips. Browser will download them even if they are not used. At least the CSS files will be downloaded (and will actually block other processing!). In some case browser will also download actual font files, even if they are not used, but this will usually be done asynchronously or after page is finished loading. But most of the time it is just a waste of bandwidth (but they are cached for 1y and could be used on other websites).

As a bonus I fixed some quotation issues of urls, because this is what I see in css documentation - https://developer.mozilla.org/en-US/docs/Web/CSS/@import

Next improvement would be to move this `@url import` into separate `link` statement in `base.html`, this way things can proceed in parallel more smoothly.

```html
        <link rel="stylesheet" href="https://fonts.googleapis.com/css?subset=latin&family=Crimson+Text:400,400italic,600,600italic,700,700italic" type="text/css" importance="low" referrerpolicy="no-referrer" />
```

After that, and margin all `css` files, this would be really clean and fast theme! :)

PS. Google Fonts Service API allows fetching multiple css files together:


```html
        <link rel="stylesheet" href="https://fonts.googleapis.com/css?subset=latin&family=Yanone+Kaffeesatz|Crimson+Text:400,400italic,600,600italic,700,700italic|Droid+Sans+Mono" type="text/css" importance="low" referrerpolicy="no-referrer" />
```

(and similarly using `@import url`).