### PR TITLE
Update svbhack with support for Pelican 4 and readtime plugin 

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -57,7 +57,7 @@
 	url = https://github.com/erfaan/pelican-theme-irfan.git
 [submodule "svbhack"]
 	path = svbhack
-	url = https://github.com/giulivo/pelican-svbhack.git
+	url = https://github.com/gfidente/pelican-svbhack.git
 [submodule "html5-dopetrope"]
 	path = html5-dopetrope
 	url = https://github.com/PierrePaul/html5-dopetrope.git


### PR DESCRIPTION
Bumps up the svbhack submodule to include a version that works with
Pelican 4 and supports the readtime plugin.