### PR TITLE
Add CC Zero to the cc_license_mark macro

### DIFF
--- a/pelican-bootstrap3/README.md
+++ b/pelican-bootstrap3/README.md
@@ -299,7 +299,7 @@ If you're using reStructuredText for writing articles and pages, you can include
 
 You can optionally declare a [Creative Commons license](https://creativecommons.org) for the content of your site. It will appear in the site's footer. To enable, use one of the following two ways for configuration.
 
-* To choose the license by name, set `CC_LICENSE` to the common abbreviated name of the license: `"CC-BY"` (require attribution), `"CC-BY-SA"` (require ShareAlike), `"CC-BY-ND"` (NoDerivatives) , `"CC-BY-NC"` (require attribution, no commercial reuse), `"CC-BY-NC-SA"` (require ShareAlike, no commercial reuse), or `"CC-BY-NC-ND"` (NoDerivatives, no commercial reuse).
+* To choose the license by name, set `CC_LICENSE` to the common abbreviated name of the license: "CC0" or "zero" (public domain mark), `"CC-BY"` (require attribution), `"CC-BY-SA"` (require ShareAlike), `"CC-BY-ND"` (NoDerivatives) , `"CC-BY-NC"` (require attribution, no commercial reuse), `"CC-BY-NC-SA"` (require ShareAlike, no commercial reuse), or `"CC-BY-NC-ND"` (NoDerivatives, no commercial reuse).
 * Alternatively, choose the licence by features:
     * `CC_LICENSE_DERIVATIVES` - `"yes"` if permitted, `"no"` if not permitted, and `"ShareAlike"` if derivatives must be shared under the same terms.
     * `CC_LICENSE_COMMERCIAL` - `"yes"` if commercial reuse is permitted, and `"no"` otherwise.

--- a/pelican-bootstrap3/templates/includes/cc-license.html
+++ b/pelican-bootstrap3/templates/includes/cc-license.html
@@ -35,25 +35,29 @@
                          br_after_icon=false,
                          attr_markup=false,
                          attr_props={}) %}
-  {% if cc_name %}
-    {% set cc_name = cc_name|lower|replace("cc-","") %}
-    {% set cc_title_suffix = cc_name|replace("by", "")|replace("-nc","-NonCommercial")|replace("-nd","-NoDerivatives")|replace("-sa","-ShareAlike") %}
-  {% else %}
-    {% set cc_name = "by" %}
-    {% set cc_title_suffix = "" %}
-    {% if (not commercial) or (commercial|lower == "no") %}
-      {% set cc_name = cc_name ~ "-nc" %}
-      {% set cc_title_suffix = "-NonCommercial" %}
-    {% endif %}
-    {% if derivatives|lower == "no" %}
-      {% set cc_name = cc_name ~ "-nd" %}
-      {% set cc_title_suffix = cc_title_suffix ~ "-NoDerivatives" %}
-    {% elif derivatives|lower == "sharealike" %}
-      {% set cc_name = cc_name ~ "-sa" %}
-      {% set cc_title_suffix = cc_title_suffix ~ "-ShareAlike" %}
-    {% endif %}
-  {% endif %}
-  {% set cc_title, cc_uri, cc_icon = ("Creative Commons AttributionCCSUFFIX 4.0 International License","https://creativecommons.org/licenses/CCNAME/4.0/","//i.creativecommons.org/l/CCNAME/4.0/80x15.png") %}
+	{% if cc_name|lower == "zero" or cc_name|lower == "cc0" or cc_name|lower == "cc-zero" %}
+		{% set cc_title, cc_uri, cc_icon = ("CC0 1.0 Universal (CC0 1.0) Public Domain Dedication", "https://creativecommons.org/publicdomain/zero/1.0/", "https://licensebuttons.net/p/zero/1.0/80x15.png") %}
+	{% else %}
+		{% if cc_name %}
+			{% set cc_name = cc_name|lower|replace("cc-","") %}
+			{% set cc_title_suffix = cc_name|replace("by", "")|replace("-nc","-NonCommercial")|replace("-nd","-NoDerivatives")|replace("-sa","-ShareAlike") %}
+		{% else %}
+			{% set cc_name = "by" %}
+			{% set cc_title_suffix = "" %}
+			{% if (not commercial) or (commercial|lower == "no") %}
+				{% set cc_name = cc_name ~ "-nc" %}
+				{% set cc_title_suffix = "-NonCommercial" %}
+			{% endif %}
+			{% if derivatives|lower == "no" %}
+				{% set cc_name = cc_name ~ "-nd" %}
+				{% set cc_title_suffix = cc_title_suffix ~ "-NoDerivatives" %}
+			{% elif derivatives|lower == "sharealike" %}
+				{% set cc_name = cc_name ~ "-sa" %}
+				{% set cc_title_suffix = cc_title_suffix ~ "-ShareAlike" %}
+			{% endif %}
+		{% endif %}
+		{% set cc_title, cc_uri, cc_icon = ("Creative Commons AttributionCCSUFFIX 4.0 International License","https://creativecommons.org/licenses/CCNAME/4.0/","//i.creativecommons.org/l/CCNAME/4.0/80x15.png") %}
+	{% endif %}
   <a rel="license" href="{{ cc_uri|replace('CCNAME',cc_name) }}deed.{{ attr_props['lang'] }}"><img alt="Creative Commons License" style="border-width:0" src="{{ cc_icon|replace('CCNAME',cc_name) }}" /></a>
   {% if br_after_img %}<br/>{% endif %}
   {% if attr_markup %}


### PR DESCRIPTION
In getpelican/pelican-themes#530 @josch reported that the `cc_license_mark` macro, written in `templates/includes/cc-license.html`, doesn't get the correct url and image when `CC_LICENSE` is set to "zero" or "cc0". That's because the format of the url is different. This change add an if to know if it is a CC Public Domain (Zero) mark before to set the license.

I tested and this works for me, the old code to set the licenses and the current code to set the public domain mark.