### PR TITLE
pelican-bootstrap3: Strip HTML tags from head title

### DIFF
--- a/pelican-bootstrap3/templates/page.html
+++ b/pelican-bootstrap3/templates/page.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% block title %}{{ page.title }} - {{ SITENAME }}{% endblock %}
+{% block title %}{{ page.title | striptags }} - {{ SITENAME }}{% endblock %}
 {% block html_lang %}{{ page.lang }}{% endblock %}
 {% block meta %}
     {% if page.author %}


### PR DESCRIPTION
… this issue must be handled in the theme.

Strip HTML tags from head title. According to getpelican/pelican#1998 this issue must be handled in the theme.