### PR TITLE
Add B-side theme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -258,3 +258,7 @@
 	path = buruma
 	url = https://github.com/ivanhercaz/buruma.git
 	branch = pelican-themes
+[submodule "pelican-b-side"]
+	path = pelican-b-side
+	url = https://github.com/fluffactually/pelican-b-side.git
+	branch = pelican-themes


### PR DESCRIPTION
Adds a theme called B-side, which is a port of [Hugo B-side](https://hugo-b-side-demo.netlify.com/). 

Screenshots, documentation, and discussion can be found in the [README](https://github.com/fluffactually/pelican-b-side), and a demo site is available at https://fluffactually.github.io/pelican-b-side-demo/ 

I read a bunch of PRs before submitting this one and couldn't find any official checklist, but here are some things I found which seemed like a good idea and have been implemented:

- [x] Add theme as a submodule. I added this theme to follow the `pelican-themes` branch, which will be the stable release branch.
- [x] Include screenshots. Two included, and demo site.
- [x] Merge cleanly. This PR is ready to go right now, not sure what will happen if some of the other PRs are merged first (possible clash in `.gitmodules`).
- [x] Some Pelican theme best practices, e.g. strip tags from titles etc. 

Let me know if anything needs to be changed or if you have any feedback. Thanks!


