### PR TITLE
Add Architect theme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -258,3 +258,7 @@
 	path = buruma
 	url = https://github.com/ivanhercaz/buruma.git
 	branch = pelican-themes
+[submodule "architect-pelican"]
+	path = architect-pelican 
+	url = https://github.com/MattWThomas/architect-pelican.git
+	branch = pelican-themes


### PR DESCRIPTION
I am creating this PR to add my port of the official GitHub pages [Architect theme](https://github.com/pages-themes/architect) from Jekyll to Pelican. The theme works exactly like the original but requires the assets plugin for CSS minification and to combine files. Let me know if this dependency is a problem, because it can easily be removed.

It also expects (but does not require) a GITHUB dictionary object which contains some repository specific information used by the theme.

This theme is extremely light and makes a great starting point for other themes and projects. Let me know if you have any other requirements or suggestions.