### PR TITLE
Fix broken pelican-b-side submodule link

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -260,5 +260,4 @@
 	branch = pelican-themes
 [submodule "pelican-b-side"]
 	path = pelican-b-side
-	url = https://github.com/fluffactually/pelican-b-side.git
-	branch = pelican-themes
+	url = https://gitlab.com/jhauh/pelican_b_side.git


### PR DESCRIPTION
This PR corrects the submodule link for pelican-b-side, a recently added theme. 

Addresses #683.

To test this fix you may need to update your submodules with `git submodule sync`

Please let me know if you have any feedback on this change or need any additional changes!