### PR TITLE
Add Stirring theme as submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -264,3 +264,6 @@
 [submodule "pelican-b-side"]
 	path = pelican-b-side
 	url = https://gitlab.com/jhauh/pelican_b_side.git
+[submodule "stirring"]
+	path = stirring
+	url = https://github.com/hansliu/pelican-stirring.git


### PR DESCRIPTION
## Purpose
Stirring: a Pelican theme. 
The theme is used for [hansliu.com](https://hansliu.com) blog.

Fully responsive, customizable for menu, lightbox for the image, cover for the article. Check out [README](https://github.com/hansliu/pelican-stirring/blob/master/README.md) for more information.
Live demo website at [here](https://hansliu.com/pelican-stirring/demo)

**The theme support Pelican 4.5.0**

## Approach
- Configuration everything as variable as possible.
- Add the latest submodule pelican-stirring as Stirring to the repo.

cc @getpelican, let me know if anything needs to be changed, thanks.



