### PR TITLE
Adds optional linking of sidebar images.

### DIFF
--- a/pelican-bootstrap3/README.md
+++ b/pelican-bootstrap3/README.md
@@ -389,14 +389,19 @@ The footer will display a copyright message using the AUTHOR variable and the ye
 
 ### Sidebar Images
 
-Include a series of images in the sidebar, with an optional header:
+Include a series of _optionally linked_ images in the sidebar, with an optional
+header.
 
+```
 SIDEBAR_IMAGES_HEADER = 'My Images'
-SIDEBAR_IMAGES = ["/path/to/image1.png", "/path/to/image2.png"]
+SIDEBAR_IMAGES = (
+    ('/path/to/image1.png', 'https://link1'),
+    ('/path/to/image2.png', 'https://link2'),
+    ('/path/to/image2.png', ''),
+)
+```
 
-Originally developed for including certification marks in your sidebar. E.g.,
-
-http://dmark.github.io
+Originally developed for including certification marks in your sidebar.
 
 ### Translations
 

--- a/pelican-bootstrap3/templates/includes/sidebar/images.html
+++ b/pelican-bootstrap3/templates/includes/sidebar/images.html
@@ -1,16 +1,20 @@
 {% if SIDEBAR_IMAGES %}
-  {% from 'includes/sidebar/macros.jinja' import title %}
+    {% from 'includes/sidebar/macros.jinja' import title %}
 
-<!-- Sidebar/Images -->
-<li class="list-group-item">
-  {% if SIDEBAR_IMAGES_HEADER %}
-  <h4>{{ title(SIDEBAR_IMAGES_HEADER, DISABLE_SIDEBAR_TITLE_ICONS, icon='external-link-square') }}</h4>
-  {% endif %}
-  <ul class="list-group" id="links">
-    {% for image in SIDEBAR_IMAGES %}
-    <img width="100%" class="img-thumbnail" src="{{ image }}"/>
-    {% endfor %}
-  </ul>
-</li>
-<!-- End Sidebar/Images -->
+    <!-- Sidebar/Images -->
+    <li class="list-group-item">
+        {% if SIDEBAR_IMAGES_HEADER %}
+            <h4>{{ title(SIDEBAR_IMAGES_HEADER, DISABLE_SIDEBAR_TITLE_ICONS, icon='external-link-square') }}</h4>
+        {% endif %}
+        <ul class="list-group" id="images">
+            {% for i in SIDEBAR_IMAGES %}
+                {% if i[1] %}
+                    <a href="{{ i[1] }}" target="_blank"><img width="100%" class="img-thumbnail" src="{{ i[0] }}"/></a>
+                {% else %}
+                    <img width="100%" class="img-thumbnail" src="{{ i[0] }}"/>
+                {% endif %}
+            {% endfor %}
+        </ul>
+    </li>
+    <!-- End Sidebar/Images -->
 {% endif %}


### PR DESCRIPTION
Updates the sidebar images feature to allow optional linking of images.

Original purpose of this PR was to add certification marks to the sidebar. This PR adds links so you can optionally add your certification verification links.

refs:

* https://github.com/DandyDev/pelican-bootstrap3/pull/190
* https://github.com/getpelican/pelican-themes/pull/388