### PR TITLE
Remove missing repository

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -80,9 +80,6 @@
 [submodule "storm"]
 	path = storm
 	url = https://github.com/redVi/storm.git
-[submodule "pure"]
-	path = pure
-	url = https://github.com/danclaudiupop/pure.git
 [submodule "jesuislibre"]
 	path = jesuislibre
 	url = https://github.com/badele/pelican-theme-jesuislibre.git


### PR DESCRIPTION
The repo https://github.com/danclaudiupop/pure.git seems to be gone. Missing submodule is blocking `git clone --recursive`.