### PR TITLE
Gum: Add optional extra CSS and JS resources

### DIFF
--- a/gum/README.md
+++ b/gum/README.md
@@ -44,15 +44,31 @@ To use Disqus, add the Disqus site name via the following variable.
 DISQUS_SITENAME = ''
 ```
 
-
 To add content or markup to the footer of every page: Add an `extra_footer.html` file to
 a directory in your `THEME_TEMPLATES_OVERRIDES` path. It is empty by default.
+
+To add extra CSS, for example to override styles without forking the Gum theme,
+you may specify either or both of these settings:
+
+```
+CUSTOM_CSS_FILES = ['list of paths to additional css static files']
+CUSTOM_CSS_URLS = ['list of URLs of additional remote css to load']
+```
+
+To add extra Javascript to the theme, you may specify either or both of these settings:
+
+```
+CUSTOM_JS_FILES = ['list of paths to additional JavaScript static files']
+CUSTOM_JS_URLS = ['list of URLs of additional JavaScript to load']
+
+```
 
 Other features include:
 
 ```
 SITESUBTITLE = 'your site subtitle'
 ```
+
 
 The following standard Pelican settings are honored:
 

--- a/gum/README.md
+++ b/gum/README.md
@@ -51,8 +51,8 @@ To add extra CSS, for example to override styles without forking the Gum theme,
 you may specify either or both of these settings:
 
 ```
-CUSTOM_CSS_FILES = ['list of paths to additional css static files']
-CUSTOM_CSS_URLS = ['list of URLs of additional remote css to load']
+CUSTOM_CSS_FILES = ['list of paths to additional CSS static files']
+CUSTOM_CSS_URLS = ['list of URLs of additional remote CSS to load']
 ```
 
 To add extra Javascript to the theme, you may specify either or both of these settings:

--- a/gum/README.md
+++ b/gum/README.md
@@ -68,7 +68,6 @@ Other features include:
 SITESUBTITLE = 'your site subtitle'
 ```
 
-
 The following standard Pelican settings are honored:
 
 ```

--- a/gum/README.md
+++ b/gum/README.md
@@ -60,7 +60,6 @@ To add extra Javascript to the theme, you may specify either or both of these se
 ```
 CUSTOM_JS_FILES = ['list of paths to additional JavaScript static files']
 CUSTOM_JS_URLS = ['list of URLs of additional JavaScript to load']
-
 ```
 
 Other features include:

--- a/gum/templates/base.html
+++ b/gum/templates/base.html
@@ -37,6 +37,17 @@
         <link rel="stylesheet" type="text/css" href="{{ SITEURL }}/theme/gumby.css" />
         <link rel="stylesheet" type="text/css" href="{{ SITEURL }}/theme/style.css" />
         <link rel="stylesheet" type="text/css" href="{{ SITEURL }}/theme/pygment.css" />
+        {% if CUSTOM_CSS_FILES %}
+          {% for item in CUSTOM_CSS_FILES %}
+            <link rel="stylesheet" type="text/css" href="{{ SITEURL }}/{{ item }}" />
+          {% endfor %}
+        {% endif %}
+
+        {% if CUSTOM_CSS_URLS %}
+          {% for item in CUSTOM_CSS_URLS %}
+            <link rel="stylesheet" type="text/css" href="{{ item }}" />
+          {% endfor %}
+        {% endif %}
 
         <script src="{{ SITEURL }}/theme/js/libs/modernizr-2.6.2.min.js"></script>
 
@@ -68,6 +79,17 @@
                  })();
             </script>
             <noscript><p><img src="http://{{ PIWIK_URL }}/piwik.php?idsite={{ PIWIK_ID }}" style="border:0;" alt="" /></p></noscript>
+          {% endif %}
+
+          {% if CUSTOM_JS_FILES %}
+            {% for item in CUSTOM_JS_FILES %}
+              <script src="{{ SITEURL }}/{{ item }}"></script>
+            {% endfor %}
+          {% endif %}
+          {% if CUSTOM_JS_URLS %}
+            {% for item in CUSTOM_JS_URLS %}
+              <script src="{{ item }}"></script>
+            {% endfor %}
           {% endif %}
 
         {% endblock head %}


### PR DESCRIPTION
With this change, the `gum` theme can be tweaked for style and behavior without forking it:

1. Create a static css or js file, eg "content/static/foo.css" and "content/static/foo.js" in your site tree.

2. In pelicanconf.py, make sure the directory containing your file is included in `STATIC_PATHS`.

3. Add to pelicanconf.py:
```python
THEME = 'gum'
CUSTOM_CSS_FILES = ['static/foo.css']
CUSTOM_JS_FILES = ['static/foo.js']

```

These will be loaded after the default Gum styles and scripts.

Remotely hosted assets can be supported as well, via `CUSTOM_CSS_URLS` and `CUSTOM_JS_URLS`.

I'm using this on my own website to eg override a few colors and tag cloud text styles:
https://slinkp.com/