### PR TITLE
corrected links in templates

### DIFF
--- a/Just-Read/readme.md
+++ b/Just-Read/readme.md
@@ -1,6 +1,6 @@
 # Just Read
 
-"Just Read" is a theme for [Pelican](http://alexis.notmyidea.org/pelican/). The fluid-width layout is based based on the Golden Grid System by [Joni Korpi](http://jonikorpi.com/).
+"Just Read" is a theme for [Pelican](http://getpelican.com/). The fluid-width layout is based based on the Golden Grid System by [Joni Korpi](http://jonikorpi.com/).
 
 ## Worth mentioning files
 

--- a/Just-Read/templates/base.html
+++ b/Just-Read/templates/base.html
@@ -130,7 +130,7 @@
 		{% else %}
 		© 2017 {{ AUTHOR }}
 		{% endif %}<br>
-		Proudly powered by <a href="http://alexis.notmyidea.org/pelican/">Pelican</a>.</p>
+		Proudly powered by <a href="http://getpelican.com/">Pelican</a>.</p>
 	</div>
 </footer>
 	{% if GOOGLE_ANALYTICS %}	

--- a/brownstone/templates/base.html
+++ b/brownstone/templates/base.html
@@ -99,7 +99,7 @@ Released   : 20100928
 
 <div id="footer">
 	<p>Copyright (c) 2008 Sitename.com. All rights reserved. Design by <a href="http://www.freecsstemplates.org/">CSS Templates</a>.</p>
-	<p>Proudly powered by <a href="http://alexis.notmyidea.org/pelican/">pelican</a>, which takes great advantages of <a href="http://python.org">python</a>.
+	<p>Proudly powered by <a href="http://getpelican.com/">pelican</a>, which takes great advantages of <a href="http://python.org">python</a>.
 </p>
 </div>
 {% include 'analytics.html' %}

--- a/notmyidea-cms-fr/templates/base.html
+++ b/notmyidea-cms-fr/templates/base.html
@@ -84,7 +84,7 @@
 
         <footer id="footer" class="body">
                 <address id="about" class="vcard body">
-                Ce site est généré par <a href="http://alexis.notmyidea.org/pelican/">Pelican</a>, un CMS réalisé en <a href="http://python.org">Python</a>.
+                Ce site est généré par <a href="http://getpelican.com/">Pelican</a>, un CMS réalisé en <a href="http://python.org">Python</a>.
                 </address><!-- /#about -->
 
                 <p>Le thème utilisé est «NotMyIdea-CMS», une version modifiée de «NotMyIdea», le thème par défaut.</p>

--- a/notmyidea-cms/templates/base.html
+++ b/notmyidea-cms/templates/base.html
@@ -85,7 +85,7 @@
 
         <footer id="footer" class="body">
                 <address id="about" class="vcard body">
-                Proudly powered by <a href="http://alexis.notmyidea.org/pelican/">pelican</a>, which takes great advantages of <a href="http://python.org">python</a>.
+                Proudly powered by <a href="http://getpelican.com/">pelican</a>, which takes great advantages of <a href="http://python.org">python</a>.
                 </address><!-- /#about -->
 
                 <p>The theme is «notmyidea-cms», a modified version of «notmyidea», the default theme.</p>

--- a/sneakyidea/templates/base.html
+++ b/sneakyidea/templates/base.html
@@ -77,7 +77,7 @@
 
         <footer id="contentinfo" class="body">
                 <address id="about" class="vcard body">
-                Proudly powered by <a href="http://alexis.notmyidea.org/pelican/">pelican</a>, which takes great advantages of <a href="http://python.org">python</a>.
+                Proudly powered by <a href="http://getpelican.com/">pelican</a>, which takes great advantages of <a href="http://python.org">python</a>.
                 </address><!-- /#about -->
 
                 <p>The theme is by <a href="http://smashingmagazine.com">Smashing Magazine</a>, thanks!</p>

--- a/waterspill/templates/base.html
+++ b/waterspill/templates/base.html
@@ -104,7 +104,7 @@
   <div id="footer">
   
     <p><a href="http://css4free.com/" title="free CSS web site designs">Free CSS Gallery</a></p>
-    <p>Proudly powered by <a href="http://alexis.notmyidea.org/pelican/">pelican</a>, which takes great advantages of <a href="http://python.org">python</a>.
+    <p>Proudly powered by <a href="http://getpelican.com/">pelican</a>, which takes great advantages of <a href="http://python.org">python</a>.
   </div><!-- end #footer -->
 
 </div><!-- end #container -->


### PR DESCRIPTION
I noticed some (6) templates still had links in the file `base.html` on http://alexis.notmyidea.org/pelican/
I wrote and ran a small bash script to replace all of them with http://getpelican.com, globally:
```
find . -type f -exec grep -l alexis.notmyidea {} \; >/tmp/pelicanfiles
for a in $(cat /tmp/pelicanfiles)
do
	echo $a
	sed 's/alexis.notmyidea.org\/pelican/getpelican.com/g' $a >${a}_NEW
	mv ${a}_NEW $a
done
```