### PR TITLE
Gum: Add template to allow injecting footer content and markup

### DIFF
--- a/gum/README.md
+++ b/gum/README.md
@@ -44,6 +44,10 @@ To use Disqus, add the Disqus site name via the following variable.
 DISQUS_SITENAME = ''
 ```
 
+
+To add content or markup to the footer of every page: Add an `extra_footer.html` file to
+a directory in your `THEME_TEMPLATES_OVERRIDES` path. It is empty by default.
+
 Other features include:
 
 ```

--- a/gum/templates/base.html
+++ b/gum/templates/base.html
@@ -122,6 +122,7 @@
         <footer id="credits" class="row">
           <div class="seven columns left-center">
 
+          {% include 'extra_footer.html' %}
                    <address id="about" class="vcard body">
                     Proudly powered by <a href="http://getpelican.com/">Pelican</a>,
                     which takes great advantage of <a href="http://python.org">Python</a>.

--- a/gum/templates/extra_footer.html
+++ b/gum/templates/extra_footer.html
@@ -1,0 +1,1 @@
+<!-- override this to add custom footer html -->


### PR DESCRIPTION
This adds a `gum/templates/extra_footer.html` template that is empty by default, so users can add to the footer by putting a file with that name in their template overrides, without forking the theme.
