### PR TITLE
Add Pelican Twenty Fifteen theme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -270,3 +270,6 @@
 [submodule "WhatsTheScoop"]
 	path = WhatsTheScoop
 	url = git@github.com:SarahRogue81/WhatsTheScoop.git
+[submodule "pelican-twenty-fifteen-theme"]
+	path = pelican-twenty-fifteen-theme
+	url = https://github.com/LayoutsHub/pelican-twenty-fifteen-theme


### PR DESCRIPTION
This PR adds Pelican Twenty Fifteen, a blog-focused Pelican theme inspired by
the WordPress Twenty Fifteen theme.

- Designed for readability and long-form blogging
- GPL v3 licensed (compatible with WordPress GPL v2+)
- Includes documentation and demo url

Theme repository:
https://github.com/LayoutsHub/pelican-twenty-fifteen-theme
