### PR TITLE
Add Reflex theme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -270,3 +270,6 @@
 [submodule "WhatsTheScoop"]
 	path = WhatsTheScoop
 	url = git@github.com:SarahRogue81/WhatsTheScoop.git
+[submodule "Reflex"]
+	path = Reflex
+	url = https://github.com/haplo/pelican-theme-reflex.git


### PR DESCRIPTION
This adds the [Reflex theme](https://github.com/haplo/pelican-theme-reflex.git) as a submodule.

Reflex is a fork of the existing [Flex](https://github.com/alexandrevicenzi/Flex) theme, with several changes and ongoing maintenance.

(I apologize for the duplicated PR. Github didn't let me reopen #789 after I force pushed my fix).

Live site for Reflex: https://haplo.github.io/pelican-theme-reflex/

<img width="1475" height="1062" alt="image" src="https://github.com/user-attachments/assets/4987992a-0ba6-439f-bd2a-18ab1d990d7d" />